### PR TITLE
Add default joystick deadzone and saturation

### DIFF
--- a/src/osd/retro/retromain.cpp
+++ b/src/osd/retro/retromain.cpp
@@ -1035,6 +1035,10 @@ static void Set_Default_Option(void)
       Add_Option("-nothrottle");
 
    Add_Option("-joystick");
+   Add_Option("-joystick_deadzone");
+   Add_Option("0");
+   Add_Option("-joystick_saturation");
+   Add_Option("1");
    Add_Option("-samplerate");
    Add_Option("48000");
 


### PR DESCRIPTION
Add a default joystick deadzone of 0 and a default joystick saturation
of 1.

Avoids a SIGFPE when deadzone and saturation have the same value.

Fixes #46