### PR TITLE
Remove the Nag/Info/Warning options

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -41,9 +41,6 @@ char RPATH[512];
 
 static char option_mouse[50];
 static char option_cheats[50];
-static char option_warnings[50];
-static char option_nag[50];
-static char option_info[50];
 static char option_renderer[50];
 static char option_osd[50];
 static char option_cli[50];
@@ -140,9 +137,6 @@ void retro_set_environment(retro_environment_t cb)
 {
    sprintf(option_mouse, "%s_%s", core, "mouse_enable");
    sprintf(option_cheats, "%s_%s", core, "cheats_enable");
-   sprintf(option_info, "%s_%s",core,"hide_gameinfo");
-   sprintf(option_nag, "%s_%s",core,"hide_nagscreen");
-   sprintf(option_warnings,"%s_%s",core,"hide_warnings");
    sprintf(option_renderer,"%s_%s",core,"alternate_renderer");
    sprintf(option_osd,"%s_%s",core,"boot_to_osd");
    sprintf(option_bios,"%s_%s",core,"boot_to_bios");
@@ -166,9 +160,6 @@ void retro_set_environment(retro_environment_t cb)
     { option_mouse, "Enable in-game mouse; disabled|enabled" },
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
-    { option_nag, "Hide nag screen; disabled|enabled" },
-    { option_info, "Hide gameinfo screen; disabled|enabled" },
-    { option_warnings, "Hide warnings screen; disabled|enabled" },
     { option_renderer, "Alternate render method; disabled|enabled" },
 
     { option_softlist, "Enable softlists; enabled|disabled" },

--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -282,39 +282,6 @@ video_changed=true;
          cheats_enable = true;
    }
 
-   var.key   = option_nag;
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         hide_nagscreen = false;
-      if (!strcmp(var.value, "enabled"))
-         hide_nagscreen = true;
-   }
-
-   var.key   = option_info;
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         hide_gameinfo = false;
-      if (!strcmp(var.value, "enabled"))
-         hide_gameinfo = true;
-   }
-
-   var.key   = option_warnings;
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         hide_warnings = false;
-      if (!strcmp(var.value, "enabled"))
-         hide_warnings = true;
-   }
-
    var.key   = option_renderer;
    var.value = NULL;
 

--- a/src/osd/libretro/libretro-internal/retro_init.cpp
+++ b/src/osd/libretro/libretro-internal/retro_init.cpp
@@ -43,9 +43,6 @@ static unsigned char ARGUC=0;
 int mame_reset = -1;
 
 /* core options */
-bool hide_gameinfo = false;
-bool hide_nagscreen = false;
-bool hide_warnings = false;
 bool nobuffer_enable = false;
 bool mouse_enable = false;
 bool cheats_enable = false;
@@ -335,15 +332,6 @@ static void Set_Default_Option(void)
       Add_Option("-mouse");
    else
       Add_Option("-nomouse");
-
-   if(hide_gameinfo)
-      Add_Option("-skip_gameinfo");
-
-   if(hide_nagscreen)
-      Add_Option("-skip_nagscreen");
-
-   if(hide_warnings)
-      Add_Option("-skip_warnings");
 
    if(write_config_enable)
       Add_Option("-writeconfig");


### PR DESCRIPTION
This fixes the current runtime issue; As per @fr500's comment, it's probably best to leave these out of the "rolling" version of MAME and only apply them to the static specific versions we keep around to avoid complications with upstream syncing.