### PR TITLE
MacOS build fix

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -134,6 +134,9 @@ ifeq ($(platform),android)
 	ARCH :=
 	LIBRETRO_OS :=
 endif
+ifeq ($(platform),osx)
+  PLATFLAGS += DONT_USE_NETWORK=1
+endif
 ifneq ($(LIBRETRO_CPU),)
 	PLATFLAGS += ARCH="" LIBRETRO_CPU="$(LIBRETRO_CPU)"
 endif


### PR DESCRIPTION
This makes a small addition to the makefile to allow this core to compile on macOS. 

According to [this document](https://github.com/libretro/mame/blob/master/src/osd/libretro/libretro-internal/README.MD) macOS requires `DONT_USE_NETWORK=1` which isn't otherwise set.

The `PLATFLAGS` section seemed to be the best place to add this as a platform-specific flag.

Using this update I can now successfully build this core on Mojave with Xcode 10. 
