### PR TITLE
Lightgun support (touchscreen and lightgun)

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -40,6 +40,7 @@ int NEWGAME_FROM_OSD  = 0;
 char RPATH[512];
 
 static char option_mouse[50];
+static char option_lightgun[50];
 static char option_cheats[50];
 static char option_renderer[50];
 static char option_osd[50];
@@ -138,6 +139,7 @@ void retro_set_audio_sample(retro_audio_sample_t cb) { }
 void retro_set_environment(retro_environment_t cb)
 {
    sprintf(option_mouse, "%s_%s", core, "mouse_enable");
+   sprintf(option_lightgun, "%s_%s", core, "lightgun_mode");
    sprintf(option_cheats, "%s_%s", core, "cheats_enable");
    sprintf(option_renderer,"%s_%s",core,"alternate_renderer");
    sprintf(option_osd,"%s_%s",core,"boot_to_osd");
@@ -162,6 +164,7 @@ void retro_set_environment(retro_environment_t cb)
     { option_saves, "Save state naming; game|system" },
     { option_auto_save, "Auto save/load states; disabled|enabled" },
     { option_mouse, "Enable in-game mouse; disabled|enabled" },
+    { option_lightgun, "Lightgun mode; none|touchscreen|lightgun" },
     { option_buttons_profiles, "Profile Buttons according to games (Restart); enabled|disabled" },
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
@@ -208,6 +211,18 @@ static void check_variables(void)
          mouse_enable = false;
       if (!strcmp(var.value, "enabled"))
          mouse_enable = true;
+   }
+
+   var.key   = option_lightgun;
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "touchscreen"))
+         lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_POINTER;
+      else if (!strcmp(var.value, "lightgun"))
+         lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_LIGHTGUN;
+      else
+         lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_DISABLED;
    }
 
    var.key   = option_buttons_profiles;

--- a/src/osd/libretro/libretro-internal/libretro.h
+++ b/src/osd/libretro/libretro-internal/libretro.h
@@ -246,6 +246,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -77,6 +77,10 @@ extern int mouseLX;
 extern int mouseLY;
 extern int mouseBUT[4];
 
+extern int lightgunX;
+extern int lightgunY;
+extern int lightgunBUT[4];
+
 extern unsigned short retrokbd_state[RETROK_LAST];
 
 extern char mediaType[10];

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -43,6 +43,14 @@ enum
    RETROPAD_R3,
    RETROPAD_TOTAL
 };
+
+enum
+{
+   RETRO_SETTING_LIGHTGUN_MODE_DISABLED,
+   RETRO_SETTING_LIGHTGUN_MODE_POINTER,
+   RETRO_SETTING_LIGHTGUN_MODE_LIGHTGUN
+};
+
 extern int NEWGAME_FROM_OSD;
 
 extern char g_rom_dir[1024];
@@ -54,6 +62,7 @@ extern int retro_pause;
 extern bool experimental_cmdline;
 extern bool hide_gameinfo;
 extern bool mouse_enable;
+extern int  lightgun_mode;
 extern bool cheats_enable;
 extern bool alternate_renderer;
 extern bool boot_to_osd_enable;

--- a/src/osd/libretro/libretro-internal/retro_init.cpp
+++ b/src/osd/libretro/libretro-internal/retro_init.cpp
@@ -46,6 +46,7 @@ int mame_reset = -1;
 /* core options */
 bool nobuffer_enable = false;
 bool mouse_enable = false;
+int  lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_DISABLED;
 bool cheats_enable = false;
 bool alternate_renderer = false;
 bool boot_to_osd_enable = false;
@@ -343,8 +344,11 @@ static void Set_Default_Option(void)
       Add_Option("-mouse");
    else
       Add_Option("-nomouse");
-   printf("yoshi debug: hardcoding lightgun for now! \n");
-   Add_Option("-lightgun");
+
+   if ( lightgun_mode != RETRO_SETTING_LIGHTGUN_MODE_DISABLED )
+      Add_Option("-lightgun");
+   else
+      Add_Option("-nolightgun");
 
    if(write_config_enable)
       Add_Option("-writeconfig");

--- a/src/osd/libretro/libretro-internal/retro_init.cpp
+++ b/src/osd/libretro/libretro-internal/retro_init.cpp
@@ -343,6 +343,8 @@ static void Set_Default_Option(void)
       Add_Option("-mouse");
    else
       Add_Option("-nomouse");
+   printf("yoshi debug: hardcoding lightgun for now! \n");
+   Add_Option("-lightgun");
 
    if(write_config_enable)
       Add_Option("-writeconfig");

--- a/src/osd/libretro/osdretro.h
+++ b/src/osd/libretro/osdretro.h
@@ -106,6 +106,7 @@ public:
  	void process_mouse_state(running_machine &machine);
 	void process_keyboard_state(running_machine &machine);
  	void process_joypad_state(running_machine &machine);
+	void process_lightgun_state(running_machine &machine);
 
 	virtual retro_options &options() override { return m_options; }
 

--- a/src/osd/libretro/video.cpp
+++ b/src/osd/libretro/video.cpp
@@ -127,6 +127,7 @@ void retro_osd_interface::update(bool skip_redraw)
    process_mouse_state(machine());
    process_keyboard_state(machine());
    process_joypad_state(machine());
+   process_lightgun_state(machine());
    RLOOP=0;
 }
 

--- a/src/osd/modules/input/input_retro.cpp
+++ b/src/osd/modules/input/input_retro.cpp
@@ -28,6 +28,9 @@ int mouseLY;
 int mouseBUT[4];
 Joystate joystate[4];
 
+int lightgunX, lightgunY;
+int lightgunBUT[4];
+
 #ifndef RETROK_TILDE
 #define RETROK_TILDE 178
 #endif
@@ -646,6 +649,36 @@ ovmy=vmy;
 	//printf("vm(%d,%d) mc(%d,%d) mr(%d,%d)\n",vmx,vmy,mouse_x,mouse_y,mouseLX,mouseLY);
 }
 
+void retro_osd_interface::process_lightgun_state(running_machine &machine)
+{
+   int16_t gun_x;
+   int16_t gun_y;
+   int16_t gun_x_raw, gun_y_raw;
+
+   // handle pointer only for now: look at libretro.cpp for libretro specific option for
+   // pointer / real lightgun
+   gun_x_raw = input_state_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
+   gun_y_raw = input_state_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
+   printf("yoshi debug! gun_x_raw = %i , gun_y_raw = %i \n",gun_x_raw, gun_y_raw);
+   // just guessing now, but could be wrong
+   lightgunX = gun_x_raw * 2;
+   lightgunY = gun_y_raw * 2;
+
+   // handle pointer presses
+   // use multi-touch to support different button inputs
+   for (int i = 0; i < 4; i++) {
+      lightgunBUT[i] = 0;
+   }
+   int touch_count = input_state_cb( 0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_COUNT );
+   if ( touch_count > 0 && touch_count <= 4 ) {
+      lightgunBUT[touch_count-1] = 0x80;
+   }
+   for (int i = 0; i < 4; i++) {
+      printf("lightgunBUT[%i] = %i : ",i,lightgunBUT[i]);
+   }
+   printf("\n");
+}
+
 //============================================================
 //  retro_keyboard_device
 //============================================================
@@ -988,7 +1021,105 @@ public:
 	}
 };
 
+//============================================================
+//  retro_lightgun_device
+//============================================================
+
+// This device is purely event driven so the implementation is in the module
+class retro_lightgun_device : public event_based_device<KeyPressEventArgs>
+{
+public:
+
+	retro_lightgun_device(running_machine& machine, const char *name, const char *id, input_module &module)
+		: event_based_device(machine, name, id, DEVICE_CLASS_LIGHTGUN, module)
+	{
+	}
+
+	void poll() override
+	{
+event_based_device::poll();
+
+	}
+
+	void reset() override
+	{
+		lightgunX=fb_width/2;
+		lightgunY=fb_height/2;
+  		int i;
+ 		for(i = 0; i < 4; i++)lightgunBUT[i]=0;
+	}
+
+protected:
+	void process_event(KeyPressEventArgs &args) /*override*/
+	{
+//		printf("here\n");
+	}
+};
+
+//============================================================
+//  lightgun_input_retro - retro lightgun input module
+//============================================================
+
+class lightgun_input_retro : public retroinput_module
+{
+private:
+
+public:
+	lightgun_input_retro()
+		: retroinput_module(OSD_LIGHTGUNINPUT_PROVIDER, "retro")
+	{
+	}
+
+	virtual void input_init(running_machine &machine) override
+	{
+		retro_lightgun_device *devinfo;
+      printf("yoshi debug: lightgun_enabled = %i \n", lightgun_enabled());
+		if (!input_enabled() || !lightgun_enabled())
+			return;
+      printf("yoshi debug: creating retro lightgun device!");
+		devinfo = devicelist()->create_device<retro_lightgun_device>(machine, "Retro lightgun 1", "Retro lightgun 1", *this);
+		if (devinfo == nullptr)
+			return;
+
+		lightgunX=fb_width/2;
+		lightgunY=fb_height/2;
+      printf("yoshi debug: retro lightgun: adding input items!");
+		devinfo->device()->add_item(
+				"X",
+				static_cast<input_item_id>(ITEM_ID_XAXIS),
+				generic_axis_get_state<std::int32_t>,
+				&lightgunX);
+		devinfo->device()->add_item(
+				"Y",
+				static_cast<input_item_id>(ITEM_ID_YAXIS),
+				generic_axis_get_state<std::int32_t>,
+				&lightgunY);
+
+		int button;
+		for (button = 0; button < 4; button++)
+		{
+			lightgunBUT[button]=0;
+			devinfo->device()->add_item(
+				default_button_name(button),
+				static_cast<input_item_id>(ITEM_ID_BUTTON1 + button),
+				generic_button_get_state<std::int32_t>,
+				&lightgunBUT[button]);
+		}
+
+		m_global_inputs_enabled = true;
+
+	}
+
+	bool handle_input_event(void) override
+	{
+		if (!input_enabled() || !lightgun_enabled())
+			return false;
+		return true;
+
+	}
+};
 
 MODULE_DEFINITION(KEYBOARDINPUT_RETRO, keyboard_input_retro)
 MODULE_DEFINITION(MOUSEINPUT_RETRO, mouse_input_retro)
 MODULE_DEFINITION(JOYSTICKINPUT_RETRO, joystick_input_retro)
+MODULE_DEFINITION(LIGHTGUNINPUT_RETRO, lightgun_input_retro)

--- a/src/osd/modules/input/input_retro.h
+++ b/src/osd/modules/input/input_retro.h
@@ -44,6 +44,10 @@ extern int mouseLX;
 extern int mouseLY;
 extern int mouseBUT[4];
 
+extern int lightgunX;
+extern int lightgunY;
+extern int lightgunBUT[4];
+
 extern Joystate joystate[4];
 
 extern int fb_width;

--- a/src/osd/modules/lib/osdobj_common.cpp
+++ b/src/osd/modules/lib/osdobj_common.cpp
@@ -284,7 +284,7 @@ void osd_common_t::register_options()
 	REGISTER_MODULE(m_mod_man, LIGHTGUNINPUT_RAWINPUT);
 	REGISTER_MODULE(m_mod_man, LIGHTGUNINPUT_WIN32);
 #else
-	//FIXME LIBRETRO LIGHTGUN
+	REGISTER_MODULE(m_mod_man, LIGHTGUNINPUT_RETRO);
 #endif
 	REGISTER_MODULE(m_mod_man, LIGHTGUN_NONE);
 #ifndef __LIBRETRO__


### PR DESCRIPTION
This adds initial lightgun support. I only tested touchscreen on an iPhone XS Max (as I don't have a real lightgun to test with, and I haven't ran this on a pc/mac yet). 

For touchscreen, single tap and double tap correspond to button 1 and 2 on MAME, respectively.