### PR TITLE
[midzeus driver] Map mandatory V key to F2

### DIFF
--- a/src/mame/video/midzeus.cpp
+++ b/src/mame/video/midzeus.cpp
@@ -351,7 +351,7 @@ uint32_t midzeus_state::screen_update_midzeus(screen_device &screen, bitmap_ind1
 	poly->wait("VIDEO_UPDATE");
 
 	/* normal update case */
-	if (!machine().input().code_pressed(KEYCODE_V))
+	if (!machine().input().code_pressed(KEYCODE_F2))
 	{
 		const void *base = waveram1_ptr_from_expanded_addr(m_zeusbase[0xcc]);
 		int xoffs = screen.visible_area().min_x;


### PR DESCRIPTION
This driver use the V key to display graphics area, sometimes the V key needs to be mapped by players so i propose to move this function to F2 (test switch).