### PR TITLE
CI cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ env:
 script:
   - if [ $TRAVIS_OS_NAME == 'linux' ]; then
     if [ $CC == 'clang' ]; then
-    make -j2 IGNORE_GIT=1 OVERRIDE_CXX="clang++-3.6" OVERRIDE_CC="clang-3.6" TOOLS=1 && ./$MAME -validate;
-    else make -j4 IGNORE_GIT=1 OPTIMIZE=0 OVERRIDE_CC="gcc-9" OVERRIDE_CXX="g++-9" TOOLS=1 && ./$MAME -validate;
+    make -j2 -f Makefile.libretro OPTIMIZE=0;
+    else make -j4 -f Makefile.libretro OPTIMIZE=0;
     fi
     elif [ $TRAVIS_OS_NAME == 'osx' ]; then
-    unset LDOPTS && make -j2 OPTIMIZE=0 USE_LIBSDL=1 TOOLS=1 && ./$MAME -validate;
+    make -j2 -f Makefile.libretro OPTIMIZE=0;
     fi
 sudo: required
 before_install:
@@ -36,4 +36,3 @@ branches:
     - master
 notifications:
   email: false
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Before sending bug reports to the upstream bug tracker, make sure the bugs are reproducible in the latest standalone release.
 
+Libretro MAME core build status:
+
+| OS/Compiler           | Status        |
+| --------------------- |:-------------:|
+| Linux GCC / OSX Clang | [![Build Status](https://travis-ci.org/libretro/mame.svg?branch=master)](https://travis-ci.org/libretro/mame) |
+
+
 --------
 
 # **MAME** #

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Libretro MAME core build status:
 | --------------------- |:-------------:|
 | Linux GCC / OSX Clang | [![Build Status](https://travis-ci.org/libretro/mame.svg?branch=master)](https://travis-ci.org/libretro/mame) |
 
+To build libretro MAME core from source you need to use `Makefile.libretro` make
+file:
+
+```
+make -f Makefile.libretro
+```
 
 --------
 


### PR DESCRIPTION
This PR does three things:

  1. Aligns Travis build settings with the settings used by RA buildbot (c.f. [Linux settings](https://github.com/libretro/libretro-super/blob/master/recipes/linux/cores-linux-x64-generic#L62) and [OSX setting](https://github.com/libretro/libretro-super/blob/master/recipes/apple/cores-osx-x64-generic#L51) on the buildbot). The CI now passes and core build failures should now be properly indicated.
  2. Adds a Travis build status button to the readme, so that we can see the build status easily.
  3. Adds libretro core build instructions to the readme.

As an aside, I find the parts of the README referring to the original MAME misleading, in particular build instructions that don't apply to this project. The README could do a better job of delimiting Libretro fork of MAME from the original MAME. I didn't do anything about this and only focused on adding things that I hope are uncontroversial, but if I get a green light to update the README I can take a stab at it.