### PR TITLE
Streamline Travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ env:
   - SUBTARGET=tiny   MAME=mametiny64
 script:
   - if [ $TRAVIS_OS_NAME == 'linux' ]; then
-    if [ $CC == 'clang' ]; then
-    make -j2 -f Makefile.libretro OPTIMIZE=0;
-    else make -j4 -f Makefile.libretro OPTIMIZE=0;
-    fi
+    make -j4 -f Makefile.libretro OPTIMIZE=0 PTR64=1;
     elif [ $TRAVIS_OS_NAME == 'osx' ]; then
-    make -j2 -f Makefile.libretro OPTIMIZE=0;
+    make -j4 -f Makefile.libretro OPTIMIZE=0;
     fi
 sudo: required
 before_install:


### PR DESCRIPTION
Some more tweaks of Travis build scripts:

  1. We don't build with clang on Linux, so the conditional branch was never taken.
  2. I added `PTR64=1` parameter to the Linux build since this is what the buildbot uses. This is in fact a no-op, since the build script sets `PTR64=1` by default, but since the buildbot does that I decided that Travis should also. If this is unnecessary then we can get rid of the conditional in the build script and just issue `make -j4 -f Makefile.libretro OPTIMIZE=0` regardless of the platform.