### PR TITLE
Disable OSX builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,20 @@ compiler:
   - clang
 os:
   - linux
-  - osx
 dist: bionic
-osx_image: xcode11
 matrix:
   exclude:
-    - os: osx
-      compiler: gcc
     - os: linux
       compiler: clang
 env:
   - SUBTARGET=tiny   MAME=mametiny64
 script:
-  - if [ $TRAVIS_OS_NAME == 'linux' ]; then
-    make -j4 -f Makefile.libretro OPTIMIZE=0 PTR64=1;
-    elif [ $TRAVIS_OS_NAME == 'osx' ]; then
-    make -j4 -f Makefile.libretro OPTIMIZE=0;
-    fi
+  - make -j4 -f Makefile.libretro OPTIMIZE=0 PTR64=1;
 sudo: required
 before_install:
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; fi"
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]; then sudo apt-get update -qq; fi"
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]; then sudo apt-get install -y --force-yes gcc-9 g++-9 libsdl2-dev libsdl2-ttf-dev libasound2-dev libxinerama-dev libxi-dev qt5-default; fi"
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'osx' ]; then brew update; fi"
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'osx' ]; then brew install sdl2 sdl2_ttf; fi"
+  - "sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y"
+  - "sudo apt-get update -qq"
+  - "sudo apt-get install -y --force-yes gcc-9 g++-9 libsdl2-dev libsdl2-ttf-dev libasound2-dev libxinerama-dev libxi-dev qt5-default"
 branches:
   only:
     - master


### PR DESCRIPTION
At the moment MAME core does not seem to work on OSX. The last build available [on the buildbot](https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/) is from November 2019 - nearly 7 months ago. But we still try to run an OSX build on Travis. This obviously fails, but there's no reason to trip Travis if we know it's not going to work anyway.

This PR disables the OSX build on Travis. Once this PR is merged I'll create a new issue specifically about broken OSX build and I'll point to this PR/commit so that whoever fixes the OSX build in the future has an easy way of restoring OSX builds on Travis.