### PR TITLE
Link libgcc and libstdc++ statically on Linux target

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1021,6 +1021,13 @@ if _OPTIONS["MAP"] then
 	end
 end
 
+-- On Linux targets link libgcc and libstdc++ statically.  See #137
+if _OPTIONS["targetos"]=="linux" then
+		linkoptions {
+			"-static-libgcc -static-libstdc++"
+		}
+end
+
 
 -- add a basic set of warnings
 	buildoptions {


### PR DESCRIPTION
Fixes #137. This time properly, I hope. Without this patch `libstdc++` and `libgcc` are linked dynamically:

```
$ ldd mame_libretro.so
        linux-vdso.so.1 (0x00007ffff83d5000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f3a5211e000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f3a52114000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f3a520f3000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f3a520ee000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f3a51f6a000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f3a51de7000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f3a51dcb000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f3a51c0a000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f3a66b34000
```

With the patch they are linked statically:

```
$ ldd mame_libretro.so
        linux-vdso.so.1 (0x00007ffc3cdef000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fbe341d1000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fbe341c7000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fbe341a6000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007fbe341a1000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fbe3401e000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fbe33e5d000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fbe48cd4000)
```

Tested locally on my machine and on Travis.