### PR TITLE
Fix MAME 0.222 OS X build

### DIFF
--- a/src/osd/modules/lib/osdlib_retro.cpp
+++ b/src/osd/modules/lib/osdlib_retro.cpp
@@ -144,3 +144,8 @@ int osd_getpid(void)
 	return getpid();
 #endif
 }
+
+osd::dynamic_module::ptr osd::dynamic_module::open(std::vector<std::string> &&names)
+{
+  return nullptr;
+}

--- a/src/osd/modules/netdev/pcap.cpp
+++ b/src/osd/modules/netdev/pcap.cpp
@@ -55,6 +55,9 @@ public:
 	{
 		pcap_dll = osd::dynamic_module::open({ LIB_NAME });
 
+		if (pcap_dll == nullptr)
+			return false;
+
 		pcap_findalldevs_dl = pcap_dll->bind<pcap_findalldevs_fn>("pcap_findalldevs");
 		pcap_open_live_dl = pcap_dll->bind<pcap_open_live_fn>("pcap_open_live");
 		pcap_next_ex_dl = pcap_dll->bind<pcap_next_ex_fn>("pcap_next_ex");


### PR DESCRIPTION
Fix link error about osd::dynamic_module::open not being implemented for OS X, implemented as no-op