### PR TITLE
Add working links to README.md for downloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Libretro MAME core build status:
 
 | OS/Compiler           | Status        |
 | --------------------- |:-------------:|
-| Linux x86_64 | ![MAME-libretro Linux x86_64](https://github.com/libretro/mame/workflows/MAME-libretro%20Linux%20x86_64/badge.svg) |
-| Windows x86_64 | ![MAME-libretro Windows x86_64](https://github.com/libretro/mame/workflows/MAME-libretro%20Windows%20x86_64/badge.svg) |
-| macOS x86_64 | ![MAME-libretro macOS x86_64](https://github.com/libretro/mame/workflows/MAME-libretro%20macOS%20x86_64/badge.svg) |
-| Android ARMv7 | ![MAME-libretro Android ARMv7](https://github.com/libretro/mame/workflows/MAME-libretro%20Android%20ARMv7/badge.svg) |
+| Linux x86_64 | [![MAME-libretro Linux x86_64](https://github.com/libretro/mame/workflows/MAME-libretro%20Linux%20x86_64/badge.svg)](https://github.com/libretro/mame/releases/download/Linux_64-bit/mame_libretro.so.zip) |
+| Windows x86_64 | [![MAME-libretro Windows x86_64](https://github.com/libretro/mame/workflows/MAME-libretro%20Windows%20x86_64/badge.svg)](https://github.com/libretro/mame/releases/download/Windows_64-bit/mame_libretro.dll.zip) |
+| macOS x86_64 | [![MAME-libretro macOS x86_64](https://github.com/libretro/mame/workflows/MAME-libretro%20macOS%20x86_64/badge.svg)](https://github.com/libretro/mame/releases/download/macOS-x86_64/mame_libretro.dylib.zip) |
+| Android ARMv7 | [![MAME-libretro Android ARMv7](https://github.com/libretro/mame/workflows/MAME-libretro%20Android%20ARMv7/badge.svg)](https://github.com/libretro/mame/releases/download/Android_ARMv7/mame_libretro_android.so.zip) |
 
 To build libretro MAME core from source you need to use `Makefile.libretro` make file:
 


### PR DESCRIPTION
Small update to the readme file, so clicking these
![image](https://user-images.githubusercontent.com/33353403/98605057-234c7300-22e5-11eb-86a8-4c7365a2c68b.png)
will let you download the core directly, instead of opening a .svg file :p 