### PR TITLE
libretro/mame 0.228

### DIFF
--- a/makefile
+++ b/makefile
@@ -384,12 +384,14 @@ endif
 endif
 
 ifeq ($(findstring arm,$(UNAME)),arm)
+ARCHITECTURE :=
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1
 endif
 endif
 
 ifeq ($(findstring aarch64,$(UNAME)),aarch64)
+ARCHITECTURE :=
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1
 endif

--- a/src/osd/modules/lib/osdlib_retro.cpp
+++ b/src/osd/modules/lib/osdlib_retro.cpp
@@ -1,28 +1,24 @@
 
 #include <stdlib.h>
-#ifdef __GNUC__
-#include <unistd.h>
-#endif
-#ifndef _WIN32
-#include <sys/mman.h>
-#else
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <mmsystem.h>
-#endif
 #include <sys/types.h>
 #include <signal.h>
 #include <time.h>
-#ifdef __GNUC__
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <memoryapi.h>
+#else
+#include <dlfcn.h>
+#include <sys/mman.h>
 #include <sys/time.h>
-#endif
-#ifdef SDLMAME_EMSCRIPTEN
-#include <emscripten.h>
+#include <unistd.h>
 #endif
 
 // MAME headers
-#include "osdcore.h"
 #include "osdlib.h"
+#include "osdcomm.h"
+#include "osdcore.h"
+#include "strconv.h"
 
 //============================================================
 //  osd_getenv
@@ -144,3 +140,223 @@ int osd_getpid(void)
 	return getpid();
 #endif
 }
+
+//============================================================
+//  osd_dynamic_bind
+//============================================================
+#if defined(_WIN32)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+// for classic desktop applications
+#define load_library(filename) LoadLibrary(filename)
+#else
+// for Windows Store universal applications
+#define load_library(filename) LoadPackagedLibrary(filename, 0)
+#endif
+#endif
+namespace osd {
+
+namespace {
+
+#if defined(_WIN32)
+class dynamic_module_win32_impl : public dynamic_module
+{
+public:
+	dynamic_module_win32_impl(std::vector<std::string> &&libraries) : m_libraries(std::move(libraries))
+	{
+	}
+
+	virtual ~dynamic_module_win32_impl() override
+	{
+		if (m_module)
+			FreeLibrary(m_module);
+	}
+
+protected:
+	virtual generic_fptr_t get_symbol_address(char const *symbol) override
+	{
+		/*
+		 * given a list of libraries, if a first symbol is successfully loaded from
+		 * one of them, all additional symbols will be loaded from the same library
+		 */
+		if (m_module)
+			return reinterpret_cast<generic_fptr_t>(GetProcAddress(m_module, symbol));
+
+		for (auto const &library : m_libraries)
+		{
+			osd::text::tstring const tempstr = osd::text::to_tstring(library);
+			HMODULE const module = load_library(tempstr.c_str());
+
+			if (module)
+			{
+				auto const function = reinterpret_cast<generic_fptr_t>(GetProcAddress(module, symbol));
+
+				if (function)
+				{
+					m_module = module;
+					return function;
+				}
+				else
+				{
+					FreeLibrary(module);
+				}
+			}
+		}
+
+		return nullptr;
+	}
+
+private:
+	std::vector<std::string> m_libraries;
+	HMODULE                  m_module = nullptr;
+};
+#else
+class dynamic_module_posix_impl : public dynamic_module
+{
+public:
+	dynamic_module_posix_impl(std::vector<std::string> &&libraries) : m_libraries(std::move(libraries))
+	{
+	}
+
+	virtual ~dynamic_module_posix_impl() override
+	{
+		if (m_module)
+			dlclose(m_module);
+	}
+
+protected:
+	virtual generic_fptr_t get_symbol_address(char const *symbol) override
+	{
+		/*
+		 * given a list of libraries, if a first symbol is successfully loaded from
+		 * one of them, all additional symbols will be loaded from the same library
+		 */
+		if (m_module)
+			return reinterpret_cast<generic_fptr_t>(dlsym(m_module, symbol));
+
+		for (auto const &library : m_libraries)
+		{
+			void *const module = dlopen(library.c_str(), RTLD_LAZY);
+
+			if (module != nullptr)
+			{
+				generic_fptr_t const function = reinterpret_cast<generic_fptr_t>(dlsym(module, symbol));
+
+				if (function)
+				{
+					m_module = module;
+					return function;
+				}
+				else
+				{
+					dlclose(module);
+				}
+			}
+		}
+
+		return nullptr;
+	}
+
+private:
+	std::vector<std::string> m_libraries;
+	void *                   m_module = nullptr;
+};
+#endif
+} // anonymous namespace
+
+bool invalidate_instruction_cache(void const *start, std::size_t size)
+{
+#if defined(_WIN32)
+	return FlushInstructionCache(GetCurrentProcess(), start, size) != 0;
+#else
+#if !defined(SDLMAME_EMSCRIPTEN)
+	char const *const begin(reinterpret_cast<char const *>(start));
+	char const *const end(begin + size);
+	__builtin___clear_cache(const_cast<char *>(begin), const_cast<char *>(end));
+#endif
+	return true;
+#endif
+}
+
+void *virtual_memory_allocation::do_alloc(std::initializer_list<std::size_t> blocks, std::size_t &size, std::size_t &page_size)
+{
+#if defined(_WIN32)
+	SYSTEM_INFO info;
+	GetSystemInfo(&info);
+	SIZE_T s(0);
+	for (std::size_t b : blocks)
+		s += (b + info.dwPageSize - 1) / info.dwPageSize;
+	s *= info.dwPageSize;
+	if (!s)
+		return nullptr;
+	LPVOID const result(VirtualAlloc(nullptr, s, MEM_COMMIT, PAGE_NOACCESS));
+	if (result)
+	{
+		size = s;
+		page_size = info.dwPageSize;
+	}
+	return result;
+#else
+	long const p(sysconf(_SC_PAGE_SIZE));
+	if (0 >= p)
+		return nullptr;
+	std::size_t s(0);
+	for (std::size_t b : blocks)
+		s += (b + p - 1) / p;
+	s *= p;
+	if (!s)
+		return nullptr;
+#if defined(SDLMAME_BSD) || defined(SDLMAME_MACOSX) || defined(SDLMAME_EMSCRIPTEN)
+	int const fd(-1);
+#else
+	// TODO: portable applications are supposed to use -1 for anonymous mappings - detect whatever requires 0 specifically
+	int const fd(0);
+#endif
+	void *const result(mmap(nullptr, s, PROT_NONE, MAP_ANON | MAP_SHARED, fd, 0));
+	if (result == (void *)-1)
+		return nullptr;
+	size = s;
+	page_size = p;
+	return result;
+#endif
+}
+
+void virtual_memory_allocation::do_free(void *start, std::size_t size)
+{
+#if defined(_WIN32)
+	VirtualFree(start, 0, MEM_RELEASE);
+#else
+	munmap(reinterpret_cast<char *>(start), size);
+#endif
+}
+
+bool virtual_memory_allocation::do_set_access(void *start, std::size_t size, unsigned access)
+{
+#if defined(_WIN32)
+	DWORD p, o;
+	if (access & EXECUTE)
+		p = (access & WRITE) ? PAGE_EXECUTE_READWRITE : (access & READ) ? PAGE_EXECUTE_READ : PAGE_EXECUTE;
+	else
+		p = (access & WRITE) ? PAGE_READWRITE : (access & READ) ? PAGE_READONLY : PAGE_NOACCESS;
+	return VirtualProtect(start, size, p, &o) != 0;
+#else
+	int prot((NONE == access) ? PROT_NONE : 0);
+	if (access & READ)
+		prot |= PROT_READ;
+	if (access & WRITE)
+		prot |= PROT_WRITE;
+	if (access & EXECUTE)
+		prot |= PROT_EXEC;
+	return mprotect(reinterpret_cast<char *>(start), size, prot) == 0;
+#endif
+}
+
+dynamic_module::ptr dynamic_module::open(std::vector<std::string> &&names)
+{
+#if defined(_WIN32)
+	return std::make_unique<dynamic_module_win32_impl>(std::move(names));
+#else
+	return std::make_unique<dynamic_module_posix_impl>(std::move(names));
+#endif
+}
+
+} // namespace osd


### PR DESCRIPTION
- missbamby.cpp: Cirsa 810601-A PCB has 4 dipswitches, not 8
- natkeyboard: Remove from ioport_manager
- cdp1863: Initialize more member variables
- luareference.rst: Move the luareference-input properties together
- aa310.cpp: Replaced i2cmem with pcf8583 RTC device.
- cmi2x:  comment cause of excessive printf output
- new WORKING machine - Namennayo (Japan) (#7599)
- galaxian.cpp: Custom port names on namenayo obfuscate the controls.
- Document parent/child for AntiM on Apple II (#7585)
- New machines marked as NOT_WORKING ---------------------------------- Hungry Hungry Hippos (redemption game) [Museo del Recreativo, The Dumping Union]
- segas32.cpp: Added save state support, and fixed backdrop color fill when screen resolution is changed. (#7583)
- ibm5170 - New working software list additions (#7596)
- supremo: placeholder for io ports
- ice_hhhippos.cpp: Add PCB ASCII layout and anonymous namespace
- magicard.cpp: decapped and dumped PIC16F84 for magicardj and magicle [Caps0ff, TeamEurope]
- playmark.cpp, powerbal.cpp: preliminary minor cleanups in preparation of subclassing and adding of the new wbeachvl MCU dumps
- hitpoker.cpp: Fix mistake in allocation size
- Temporary hack so most DRC games work on the M1/Apple Silicon. [R. Belmont, balr0g, Vas Crabb]
- ncr5380n: fix MAME lockup introduced in the previous change [R. Belmont]
- novag_snova: A-H are on the right side of leds
- firebeat.cpp: Fixed input range for wheels in Keyboardmania games. (#7607)
- ds1302: Add DS1202 variant
- v40, v50, v53: Allow configuration registers to be read back
- zt8802: Moderate de-skeletonization
- rebalance sound after ymz280b change
- trebol: Transfer to missbamby.cpp driver, since hardware appears to be almost the same
- atarisy1: correct LSI BIOS 136032.115 regression
- playmark.cpp, powerbal.cpp: started splitting in derived classes
- Added Flip Screen configuration to Indiana Jones and the Temple of Doom (cocktail) [GadgetFreak]
- New working machines -------------------- Sphinx Commander (v2.00) [hap, anonymous]
- a2ssc: Add DIP switch locations and correct their bit assignments; mirror register addresses
- a2ssc: More minor corrections
- a2ssc: Connect RTS output
- am9517a: simplify software request handling
- WonderSwan updates: (#7428)
- Clones promoted to working ---------------------------- Cat and Mouse (set 2) [Paul Swan]
- VG5000µ fix latched attributes on delimiter. (#7610)
- dim68k: add DUART, use views for boot-time bankswitch, some minor cleanup [R. Belmont]
- astrcorp.cpp: two more address bits are involved in the magibomb descrambling
- New clones marked as NOT_WORKING -------------------------------- Crime Patrol v1.0 [Dragon's Lair Project]
- atarittl.cpp: removed pongdbl since it has been moved and emulated in pong.cpp [gregf]
- apple2, apple2e, apple2gs: Add emulation of Apricorn Super Serial Imager as slot option [AJR, Apple II Documentation Project]
- laserbat.cpp: Correct ROM labels for rev 2 Cat and Mouse
- New working clones ------------------ Big Fight - Big Trouble In The Atlantic Ocean (Japan, rev F) [Phil Bennett, The Dumping Union]
- ncr5380n: halt dma on phase mismatch
- laserbat.cpp: Change Cat and Mouse game description based on suggestion
- vgmplay.cpp: Fix wswan validation error (nw)
- readme: minor tweak
- romp: initial storage channel implementation
- champbwl.cpp: added controls for cocktail mode
- simultano: program version appears to be B
- plugins/cheat: Migrate remaining XML cheat code for Lua API changes.
- New machines marked as NOT_WORKING ---------------------------------- Happy Pierrot [trap15]
- New working clones ------------------ Kasparov Simultano (ver. C) [bataais]
- -arm7: Added optional logging for Windows CE calls. [Ryan Holtz]
- esqpump: remove unneeded logerror
- util/xmlfile.cpp: C++ comment conversion
- plugins/data: use history.xml and add xml parser for it
- ioport.cpp: Eliminate redundant std::string("...").c_str() pattern
- New machines marked as NOT_WORKING (#7606)
- plugins/data: remove logging and fix query
- hitpoker.cpp, tlc34076: Initialize more pointers and variables
- -psx.xml: Cleaned up metadata. [Angelo Salese] * Marked dumps from unknown sources as bad. * Tested many software items. * Marked LibCypt discs with missing subchannel data as unsuppored.
- model2.cpp: Documentation update for Dead or Alive, Model 2A version
- aprissi: ROM version note
- hash.cpp, hashing.cpp: Change string processing to use std::string_view parameters; add sum16 type
- Further additions of std::string_view - corefile.cpp, fileio.cpp: Change puts to take a std::string_view parameter - rendlay.cpp: Use std::string_view instead of bare pointers in various functions - vecstream.h: Add std::string_view conversion operator to obtain output buffer without needing to make it a C string with explicit null termination - xmlfile.cpp: Add get_attribute_string_ptr method that distinguishes between empty strings and absent attributes without falling back to C strings
- romcmp: Add -h option to print hashes and 16-bit sums for all files
- clifront.cpp: Restore line accidentally deleted in aa29519528cb3dbdbfac56819bea670ed8c56c5d
- -arm7: Moved WinCE call logging into a separate .hxx file. [Ryan Holtz]
- Cassette image processing cleanup - Add cassette_image::image_read_byte method for reading one byte at a time - coco_cas.cpp: Eliminate dependency on emucore.h - thom_cas.cpp: Declare some temporary variables much closer to where they are used - tvc_cas.cpp: Read and write entire sectors at a time
- plugins/data: better hiscore parsing
- New machines marked as NOT_WORKING ---------------------------------- Heroine's Memory [The Dumping Union]
- odyssey2: fix loading games with -cart not working
- New machines marked as NOT_WORKING ---------------------------------- Bingo Circus (terminal) [Phil Bennett]
- bingoc.cpp: fixed clang build
- palette.cpp: Use std::fill instead of memset for dirty vector; add range check
- Low-level #include overhaul - vecstream.h: Revert changes made in aa29519528cb3dbdbfac56819bea670ed8c56c5d. The std::string_view conversion has been made a non-member function (util::buf_to_string_view) and moved to coretmpl.h. - strformat.h: Remove the using declaration importing util::string_format into the global namespace. It has been moved to emucore.h and a few tool sources; other references have been qualified. - osdcore.h: Split out file, directory and path classes and methods to a new header (osdfile.h), Doxygenizing the documentation comments. - Disaggregate many #includes that were including other standard or custom headers. emu.h now includes basically the same things that it did, but other headers have been streamlined; for instance, emucore.h no longer stealth-includes osdcore.h several ways.
- disasmintf.h: Attempt at fixing build on other compilers
- vbiparse.cpp: Add missing #include
- options.h: Be more honest about #including prerequisites
- windir.cpp, winrtdir.cpp: string_format calls need qualification now
- ARM: fix carry flag in ADC instruction. [Sandro Ronco]
- plugins/data: more hiscore improvements
- New machines marked as NOT_WORKING ---------------------------------- Fatal Fury Special (SNES bootleg) [Apocalypse, iq_132]
- snesb.cpp: Fix clang build by removing leftover tables
- New working clones ------------------ Sega Bass Fishing Deluxe (USA) [Brian Troha, The Dumping Union] Dirt Devils (USA, Revision A) [Brian Troha, The Dumping Union]
- Minor clean ups: Missing ")" and standardize loading address statements
- emumem: more idiomatic way to access members inherited from argument-dependent base templates (may or may not work around GCC11 bug causing #7616)
- coco_midi: fix msvc build
- coco: standardize include guard
- abc1600: Renamed floppy software list. [Curt Coder]
- abc1600: Some cleanup in the MAC. [Curt Coder]
- odyssey2: add notes
- galpani2: Correct the rom loading for one of the games, generate an image list
- odyssey2/voice: remove unused function
- Purge #include "rendlay.h" where not necessary
- render.h, rendlay.h: Dependency refactoring - render.h: Split out layout class declarations into rendlay.h, with some adjustments for the resulting incomplete types (std::reference_wrapper unfortunately does not allow these by C++17 rules) - rendlay.h: Move old header contents to layout/generic.h
- New machines marked as NOT_WORKING ---------------------------------- Sonic Blast Man's Janken Battle [Phil Bennett]
- fix dragondos Disk BASIC tokens
- misc spelling fixes
- odyssey2: add service test cart 7seg output
- New machines marked as NOT_WORKING ----------------------------- SM1810 [Carl, Alexander Kholodov]
- cr16cdasm.cpp: Use precompiled header
- apple2c: fix RdRAM2 ($C011) return value on IIc and IIc Plus. (Github issue #7640). [R. Belmont]
- osdwindow.cpp: Centralize basic functions; de-virtualize various getters
- Attempt at fixing Windows build
- Second attempt at fixing Windows build (function is now defined in base class)
- odyssey2/ktaa: re-add support for 16KB size
- cpu: Allow recompilers to work with W^X policy
- osdwindow.cpp: Make monitor code a little safer
- cpu: Slightly reduce the number of page protection state changes
- Make "slot" feature in software lists and a few related features case-sensitive
- Simplify snapshot/quickload callback parameters; remove some uses of auto_alloc_array
- Fix DRC build breakage under Emscripten. [Justin Kerk]
- kopunch.cpp: Acknowledge coin IRQs
- d6800, vip: added chip8 software list (72 titles, curated)
- tmc1800: added note
- mac: Optionally hook up the new skeleton SWIMs
- Tidy up loose ends:
- d6800: tidied up a few things.
- wrally.cpp: fixed MT07836
- Added audio CD to DrumMania (GQ881 VER. JAD), but the game is still not playable [xuserv]
- videopac.xml: mark timelordpl as baddump
- fix several genuine issues found by coverity
- a2bus/mouse.cpp: Fix regression caused by MCU port C lines being high after reset
- hh_cop400: fix mdallas keypad problem
- s14001a: get rid of compiler warning
- New machines marked as NOT_WORKING ---------------------------------- Champion Pool (v1.0) [caius]
- odyssey2: switch p1/p2 joysticks
- zippath.cpp: Checkpoint - Adopt std::string_view as the input parameter type for most functions. (This necessitates some explicit copying to std::string since other APIs have not been updated yet.) - Remove zippath_parent_basename, whose implementation was utterly broken and fortunately unused.
- dim68k: fix boot bankswitch, additional FDC & RS232 hookups, it now tries to boot a floppy [R. Belmont]
- Fixed some minor coverity warnings
- i82586: fix address hash and multicast setup bugs
- util/zippath.cpp: Fix suffix for zip archives.
- dim68k: more fdc hookup, CP/M 68K now partially loads. [R. Belmont, O. Galibert]
- New machines marked as NOT_WORKING ---------------------------------- Mini Guay [jordigahan, ClawGrip]
- miniguay.cpp: Hook up some devices
- dim68k: add serial keyboard [R. Belmont]
- coco_midi: tidy namespace
- miniguay.cpp: very minor notes update
- New machines marked as NOT_WORKING
- **Fixed mistake with rtpca25
- abc1600: Add debugging notes.
- rtpc: Fix clang compile.
- design: Hook up addressable latches
- - undrfire.cpp:  Fixed shifter displays for cbombers (MT#7843)
- zippath.cpp: Checkpoint #2 - Fix unintialized variable issue in zippath_resolve - Eliminate one internal helper function
- wicat.cpp: Sound notes
- mcs48: separate F0/F1 from upi41 STS, fix F0 flag read from upi41_master_r
- wicat.cpp: nopw must be aligned
- mcs48.h: update note
- isbc: sm1810 tries to boot irmx, fails due to different 215 wakeup address
- crbaloon: Add accurate video timings and watchdog; reduce CPU clock; clean up various things
- ladybug: Add raw screen parameters
- New machines marked as NOT_WORKING (#7648)
- blktiger_ms.cpp: attempted to make it do something. Still a long way to go.
- mcs48: small bugfix for DA  A
- mcs48: correct copyright holders
- New NOT_WORKING software list additions
- m68000: Don't clear interrupt input state upon reset
- mcs48: single line comments c++ style
- alphasma3k: fixed mame.lst
- odyssey2: correct copyright holders
- i8244.h: add pinout info
- itech32.cpp: fixed MT07846
- Confirm DIP defaults in Shogun Warriors/Fujiyama Buster by manual
- Miscellaneous cleanup.
- isbc: sm1810 has an 80 track drive
- metro.cpp, hyprduel.cpp: Move interrupt control (mostly) down into VDP
- Actually build the accepted variants list in floppy
- gamegear, sg1000, sms software list additions (#7649)
- Provide the variants to the floppy formats
- relief.cpp: Add in checksum information as printed on ROM labels. Make easier to ID earlier undumped sets.
- Update floptool to the new prototypes
- m740: Restore T flag correctly during PLP and RTI. Previous emulation inherited from the 6502 base device caused these instructions to always set T in P and not affect instruction decoding at all.
- miniguay.cpp: Add PCB ASCII layout
- dim68k: Fix the floppy drive type [R. Belmont]
- imd_fmt.cpp: if an IMD image is 40 track but the drive is HD, put the data on even tracks like hardware would show [R. Belmont]
- imd_dsk: add missing file [R. Belmont]
- astrcorp.cpp: added GFX ROM for magibombe [Phil Bennett]
- - m950x0: Added implementation for STmicro M950x0 SPI EEPROM series. [Ryan Holtz]
- imd_dsk: use has_variant() and accept either HD or QD as 80-track drives [R. Belmont]
- - m950x0: Removed private specifier in favor of protected. [Ryan Holtz]
- -m950x0: Fixed validation. [Ryan Holtz]
- machine/seibuspi: correct copyright holders
- rx78: - fixed colours, keyboard and cart loading to allow the new carts to work. [Robbbert] - fixed loading of real tapes [Haze]
- rx78: New working software --------------------------- Sekigahara Super Motocross [from Hubz]
- tlcs900: fix disassembly of PC-relative addressing
- mcs48: fix possible problem with A11 and RET during interrupt
- c64_flop_misc.xml: fix typo
- Partial revert, try to make it clear that is the intended behaviour.
- imd_dsk: restore # of tracks check [R. Belmont]
- metro.cpp: VDP clock is not so standard on some PCBs
- New working clones ------------------ Zabavni Karti (cyrillic, Bulgarian, encrypted) [Roberto Fresca, Grull Osgo, Ioannis Bampoulas]
- Zabavni Karti improvements: * Proper inputs from the scratch. * Some DIP switches sorted out. * Added technical notes.
- Disable msvc windows CI, breaks for probably unfisable heap space issues
- videopac.xml: re-added Flash Point PAL conversion hack since it was sold on cartridge
- SWIM2: Enough of the write processing to make the timing calibration work.
- videopac.xml: add unmodified dump of timelordpl [René van den Enden (Rene_G7400)]
- m740: Core overhaul - Change many instruction timings and dummy fetch patterns to match Mitsubishi documentation rather than 6502 behavior - Add overrides to be used for separable data space in future M50734 emulation - Fix incorrect addition of Y to address of EORT $zp - Eliminate INCT A and DECT A instructions (T=1 has no effect on INC A or DEC A) - Add STP and WIT instructions (not distinguished for now) - Eliminate generic M740 device type (not used by anything)
- cps1.cpp: Documented turbo mode DIP switch settings for sf2rb (Street Figher II' Rainbow hacks). [Rotwang]
- astrcorp.cpp: added eeprom dump for magibombe [Phil Bennett]
- New machines marked as NOT_WORKING ---------------------------------- Tsururin Kun [Phil Bennett]
- bus/neogeo: Cleaned up SMA protection bitswaps.
- konmedal.cpp: added dip switch definitions for slimekun
- * Added PLD dumps to Maygay M1, Scorpion 2 and Scorpion 4
- Zabavni Karti improvements: Added PLD.
- mac/swim2: Add apple drivers and associated communications
- New machines marked as NOT_WORKING ---------------------------------- Tab Products E-22 Display Terminal [Bitsavers]
- New clones marked as NOT_WORKING -------------------------------- Roland HS-80 Programmable Polyphonic Synthesizer [Andreas Markusen, DBWBP]
- cps1.cpp: Documented projectile path DIP switch settings for sf2rb (Street Fighter II' Rainbow hacks). [Rotwang]
- konmedal.cpp: added inputs for tsururin
- hp2640.cpp: Added tape emulation. (#7625)
- -Acorn Archimedes code reorganization: (#7627)
- astrcorp.cpp: Derive screen timings from crystals, and cleaned up code. (#7657)
- ksys573.cpp, machine/k573mcr.cpp: Implemented JVS memory card reader device for System 573. (#7659)
- New machines marked as NOT_WORKING ---------------------------------- Surprise 5 (Ver. 1.19) [Ioannis Bampoulas]
- some jpmimpct.cpp refactoring (#7645)
- roland_s10.cpp, roland_s50.cpp: Add skeleton sampler devices
- Fixed sound ROM size on High Roller (nw)
- blitz68k.cpp: updated TODO and notes
- i8244: changed character layer priorities
- jpmimpct.h: Fix clang error: private field 'm_alpha_clock' is not used [-Werror,-Wunused-private-field]
- dim68k: Temporarily patch key table so Return works, and preliminary lo-res graphics support [R. Belmont]
- dim68k: fix text color back to white [R. Belmont]
- dynax.cpp, hnayayoi.cpp: Identified some DIP switches.
- fix 'arcade' build - fixes recent ksys572 memory card update & jpmimpct update
- New working clones ------------------ Rabbit (Japan 3/6?) [CoolMod, The Dumping Union]
- blitz68k.cpp: switched to logmacro, adjusted inputs for surpr5
- i8244: split big screen_update function into several pieces
- New working software list additions ----------------------------------- videopac: Rash [hap]
- fmtowns_flop.xml: 1 new dump
- dim68k: better palette, fixed text rendering glitch [R. Belmont]
- astrcorp.cpp: allow magibomb to boot (#7665)
- New working machines -------------------- Facit DTC (DeskTop Computer) [Luxor ABC arkivet, Curt Coder]
- New working software list additions ---------------------------------- Burger Shop Champion Racer Mobile Suit Gundam Perfect Mah-jongg The Prowrestling Ultraman [Gaming Alexandria, SSJ, Robbbert] {for RX78}.
- fmtowns_cd.xml: 16 new dumps, 13 replacements, 6 missing floppies added
- New working software list additions ------------------------------- Graphics Mathematics [Gaming Alexandria, SSJ] {for RX78}.
- dynax.cpp, hnayayoi.cpp: Added DIP switch locations as shown in service mode for some games, identified one more DIP switch for hnkochou.
- metro.cpp: Fix tilemap offset regression imagetek_i4100.cpp: Add state of CRTC related value for debug also fixed MT #07845
- Zabavni Karti improvements:  * Added complete cyrillic/roman setup instructions.  * Added technical notes.  * Some clean-ups.
- New clones marked as NOT_WORKING -------------------------------- New Draw 8 Lines (Version 2.1) [Ioannis Bampoulas]
- abc800: Fixed ROM size.
- New working clones ------------------ beatstage 4th MIX (ver KA-A) [xuserv]
- New working machines -------------------- Club Card (ver. 1.1 English) [Roberto Fresca, Ioannis Bampoulas]
- updated mame.lst...
- mpu4.cpp, nwk-tr.cpp: Use strcmp instead of core_stricmp for per-game hacks
- rx78: split software list into two.
- rtpc010, rtpc015: fixed crash soon after start
- Club Card improvements: Reworked inputs from the scratch. Completed DIP switches and fixed lamps layout.
- Club Card improvements: Created a default NVRAM that allows the game to boot.
- goldstar.cpp: attempted a dump of the met47s01 device [Ioannis Bampoulas]
- New machines marked as NOT_WORKING
- hikaru.cpp: add pinout for aica jtag connector
- ef9340_1: add pinout reference
- zexall: correct license tag
- unspdasm.h: correct license tag
- ews4800: Fix clang compile.
- bus/qbus: Replace explicit CPU tag lookup with required_address_space
- c64/dela_ep256: Use required_device_array
- Fix build on FreeBSD/powerpc64
- -Improved accuracy of System 573's digital I/O audio emulation. (#7664)
- oricext.cpp, microdisc.cpp: Use device finders
- - sa1110: Added skeleton handling for UDC sub-device handling. [Ryan Holtz]
- swim2: Add reading, writing gcr up to track 63.
- btoads.cpp: fixed MT07838
- astrcorp.cpp: partially decrypted magibombd, same problem as astoneag, hangs at ROM error
- New machines marked as NOT_WORKING ---------------------------------- New! Cherry Plus (Ver. 3.10) [Ioannis Bampoulas]
- tabe22: Make it mostly work
- monty: use ioport_array for buttons
- jpmimpct.cpp: Improved service inputs for consistency with other drivers
- applefdintf: Correct the not-present option
- floppy: fix precision issue and missing cache clear on write
- i8244: remove confusing invalid_register function
- mess.flt: added ews4800.cpp
- videopac.xml: add usa games index
- floppy: fix regression in new floppy [O. Galibert]
- dc42: better cell size on save and remove extraneous logging
- -osd: Clean up inline maths utilities. * Removed inline assembly for operations compilers handle well. * Added ARM and AArch64 implementation for a few operations. * Added unsigned integer add with carry out operations.
- osd: Make preprocessor usage a bit more consistent in inline utilties for PPC/ARM.
- Software list items promoted to working --------------------------------------- gamegear: X-Terminator v2.1 for Game Gear (USA, Euro) X-Terminator v2.1J for Game Gear (Jpn) [Wilbert Pol]
- Started refactoring / researching more of jpmsys5.cpp (#7667)
- videopac.xml: categorize main list as 1stparty-3rdparty-unreleased instead of applications-educational-games
- videopac.xml: move frogger to 3rdparty too
- naomi.cpp: document few undumped games (nw)
- votrhv.cpp: correct a comment about ram types [Lord Nightmare]
- swim2: Add mfm read, fix mfm write and mfm detection.  SWIM2 seems done at that point.
- new NOT WORKING machines (#7675)
- video/k057714.cpp: Implemented display resolution register and various fixes to drawing. (#7677)
- artwork/chess: change chess symbols to svg
- New machines marked as NOT_WORKING
- mess.lua: Fix full build
- hdc92x4.cpp, i8271.cpp: Clean up time logging
- in213: Add BIOS V2.1 [MattisLind]
- astrcorp.cpp: added preliminary decryption for winbingo and clones and zoo. Also renamed zoo to zulu
- views: Fix some issue when the view does nor span an exact power-of-two block
- wiping: fix spriteram
- fmtowns_cd.xml, pc98.xml: Correct Engage Errands titles.
- ikt5a: Add keyboard
- astrcorp.cpp: added preliminary decryption for dinodino
- megadriv.xml: corrected year info for term2 [Arcade Shadow]
- New machines marked as NOT_WORKING ---------------------------------- Pontoon (Konami) [Michel Pichot]
- jpmimpact.cpp / jpmimpactsw.cpp progress on non-video fruit machines [David Haywood] - Hopper tweaks to allow many more sets to boot - Return 0xffff from some unknown memory addresses to allow later games to boot (security / anti-tamper?) - Better per-game defaults to allow more sets to boot - Alt reel configs for a handful of ACE games to allow them to boot - Remove a few bad dumps - Correct ROM loading on several sets - Fix up manufacturer information for several sets - Use timed coin optos for coins so that they insert reliably without triggering scam detection - Started adding per-game input configurations - Various notes / observations based on behavior to identify where improved hookups are still needed - Added myself as copyright holder as I've made significant changes to the driver at this point if prior work is included.
- hng64: Added flat shaded polygons, with no texture or lighting (#7676)
- extrema.cpp: added preliminary decryption for bloto
- xybots.cpp: fixed MT05379
- ikt5a: Add gfxdecode
- New machines marked as NOT_WORKING ---------------------------------- Get A Way [hap, Sam Grech]
- jpmimpct.cpp: reel lamps upside down it seems (nw)
- getaway: show garbage on screen
- getaway: small fix with dmask
- getaway: show the complete vram for now
- cosmicg: Driver overhaul - Separate driver from cosmic.cpp - Add MC6845 CRTC and use it for all video updates - Configure screen with raw parameters - Add support for display flipping in cocktail mode
- cosmic.cpp: Cosmic Guerilla is in another driver now
- cosmic.cpp: Add raw screen timing parameters based on schematics
- extrema.cpp: added preliminary decryption for adults, extrmth, extrmti, luckshel, strlink
- 8080bw: mark cosmicmo as bootleg
- m740: NMI does not exist; update notes
- Forte Card improvements: Added a default serial EEPROM after an exhaustive reverse-engineering work of Grull Osgo. Refactored and cleaned up the sets and driver. Added technical notes.
- extrema.cpp: added preliminary decryption for the rest of the sets
- ibm5170 - New working software list additions (#7653)
- ibm5150 - New working software list additions (#7654)
- Much more core std::string_view modernization - Remove corestr.h from emu.h; update a few source files to not use it at all - Change strtrimspace, strtrimrightspace and core_filename_extract_* to be pure functions taking a std::string_view by value and returning the same type - Change strmakeupper and strmakelower to be pure functions taking a std::string_view and constructing a std::string - Remove the string-modifying version of zippath_parent - Change tag-based lookup functions in device_t to take std::string_view instead of const std::string & or const char * - Remove the subdevice tag cache from device_t (since device finders are now recommended) and replace it with a map covering directly owned subdevices only - Move the working directory setup method out of device_image_interface (only the UI seems to actually use the full version of this) - Change output_manager to use std::string_view for output name arguments - Change core_options to accept std::string_view for most name and value arguments (return values are still C strings for now) - Change miscellaneous other functions to accept std::string_view arguments - Remove a few string accessor macros from romload.h - Remove many unnecessary c_str() calls from logging/error messages
- Zabavni Karti: Added Cyrillic names to the inputs descriptions.
- spectrum_cass.xml:  Updated Year and Publisher info for numerous entries. [ArcadeShadow]
- Fix compile.
- gauntlet: Add missing triggers, will do better later
- rx78: Fixed color in theprowr and seki. Added notes.
- troopy: one gfx rom is confirmed bad [chaneman]
- kingpin: Various updates
- New working clones (#7684)
- -osd/windows: Minimise full-screen windows on losing focus (#2997).
- osd: Rearranged window title to put system name first
- kingpin: Fix maxideal NVRAM checksum
- gauntlet2p: Fix slapstic communication
- peter packrat: fix slapstic too
- 6522via.cpp: Distinguish some different VIA types
- Firebeat: Fix flash clearing for pop'n music (#7548)
- Apple 2 floppy drive (diskiing, diskiing13): added sounds (#7685)
- Forte Card improvements: Added Coin In/Out counters and Auto Play DIP switch. Also some technical notes.
- extrema.cpp: corrected spelling of Ukraine
- jungleyo.cpp: hacked the bare minimum to make it do something
- kpontoon: corrected hardware info
- flopimg: Change the extracted bitstreams into vector<bool> flopimg: Change the extracted sectors into vector<vector<uint8_t>> flopimg: Add a Mac sector extraction apple 3.5 gcr: Generalize track creation/extraction apple 3.5 gcr: Add a pure sector format
- mac: add additional VIA delay for Cuda, maclc520 and maccclas boot [R. Belmont]
- New working clones ------------------ Puchi Carat (Ver 2.04A 1997/11/08) [TeamEurope, Ryan Holtz, The Dumping Union]
- ncr5380n: assert drq after req with phase mismatch
- galaxian.cpp: Fixed sprite clipping issue in namenayo. [David Haywood] (#7688)
- getaway.cpp: various updates, promoted to working (#7686)
- ATTR_UNUSED, do you welcome C++17 in your heart and mind?
- getaway: move register notes into io_w function
- -getaway.cpp: Fixed steering control.
- getaway: update notes
- flopimg: Fix gcr checksum
- swim1: Embed the iwm
- mac128.cpp: VIA note
- selsoft.cpp: Fix use of strmakelower
- swim1.h: Fix clang build
- jungleyo.cpp: completed decryption, added inputs and (bad) sound
- getaway: re-add imperfect controls flag
- genie.lua: Attempted fix for GCC build
- i8244: fix recent regression
- rx78: add note about RAM
- jungleyo.cpp: added a second tilemap
- quizshow: add cassette device
- jpmimpact.cpp: work on correctly mapping buttons for each machine [David Haywood] (#7683)
- sspeedr: correct company string
- mac128: start new IWM hookup, not working properly yet [R. Belmont]
- bgfx: Added lcd-grid shader. (#7691)
- bgfx: Fixed overlapping register in lcd-grid shaders and compiled for Direct3D, SPIR-V, Metal, etc.
- -docs update:
- mac128.cpp: Move macros after PCH to avoid issues.
- rx78_cart.xml: Added complete serial number for Donjara and moved it to the correct place in the sequence. [Dave 'Foxhack' Silva] (#7692)
- - amstr_pc.cpp: added hardware info for ppc512 / ppc640 [Guru]
- jungleyo.cpp: very minor comments corrections
- New NOT_WORKING software list additions --------------------------------------- sms.xml: Action Replay (v. 1.02) [Apocalypse]
- iwm: motor/devsel is a little weird, hope this works
- buggychl: decrease steering wheel sensitivity
- New clones marked as NOT_WORKING -------------------------------- The Hole (bootleg of The Pit) [caius] The Porter (bootleg of Port Man) [caius]
- raiden: lower the OKI volume
- raiden: tweak OKI volume a bit more
- Correct ROM labels and location for ufosensib
- getaway: change steering controller type 'ad stick' to paddle
- iwm, swim1: devsel makes more sense now, I think
- New machines marked as NOT_WORKING ---------------------------------- unknown 'Rolla' slot machine [caius]
- floppy: Add dir read on apple floppies
- mccpm.cpp: Clocking note
- rolla.cpp: moved set to skylncr.cpp
- alphasma3k.cpp: Add note about firmware updates (#7698)
- eigccarm.h: fix unterminated #if [R. Belmont]
- getaway.cpp: Confirmed accelerator range is correct by examining game code.
- srcclean in preparation for branching release
- nmk16.cpp: Fixed 'redhawks' bad graphics, and added placeholders for undumped PROMs and PLDs. (#7696)
- Renamed chip8 software list so the filename matches the list name.
- input.cpp, inputdev.cpp: Misc. fixes - Fix a recent regression with processing XInput DPAD input item tokens - Prevent code_to_token from blowing up in strange cases
- wscolor.xml: Software part features must be unique.
- floppy: When the floppy head stays on an unformatted track from more than an hour and ten minutes and reading happens then interval_index*2+1 overflows.  Wow. Found and tracked down by Colin Howell, with much thanks.
- Version bump
- libretro: correct Makefile.libretro
- libretro: correct libretro osd for mame 0.228
- Unbreak aarch64 and arm builds (#7708)
- libretro: refactor osdlib_retro for mame 0.228
