### PR TITLE
[iOS] Fix building for iOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,6 +108,17 @@ libretro-build-osx-x64:
     <<: *global_cache
     key: "$CI_COMMIT_REF_SLUG-osx-x64"
 
+# iOS
+libretro-build-ios-arm64:
+  tags:
+    - macosx-packaging
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-ios-arm64"
+
 # Android ARMv7a
 android-armeabi-v7a:
   extends:

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -155,6 +155,18 @@ endif
 ifeq ($(platform),osx)
   PLATFLAGS += DONT_USE_NETWORK=1
 endif
+
+ifeq ($(platform),ios-arm64)
+  PLATFLAGS += DONT_USE_NETWORK=1
+	LIBRETRO_CPU = arm64
+	ARCH = arm64
+	LIBRETRO_OS = ios-arm64
+	IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+	CC = cc -arch arm64 -isysroot $(IOSSDK) -miphoneos-version-min=11.0
+	CXX = c++ -arch arm64 -isysroot $(IOSSDK) -miphoneos-version-min=11.0
+	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
+endif
+
 ifneq ($(LIBRETRO_CPU),)
 	PLATFLAGS += ARCH="" LIBRETRO_CPU="$(LIBRETRO_CPU)"
 endif

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -627,6 +627,12 @@ if _OPTIONS["osd"]=="retro" then
 			"__LIBRETRO__",
 			"NDEBUG",
 		}
+
+	if _OPTIONS["LIBRETRO_IOS"] == "1" or _OPTIONS["LIBRETRO_TVOS"] then
+		defines {
+			"TARGET_OS_IPHONE"
+		}
+	end
 end
 -- RETRO HACK
 

--- a/src/osd/modules/lib/osdlib_retro.cpp
+++ b/src/osd/modules/lib/osdlib_retro.cpp
@@ -268,7 +268,7 @@ bool invalidate_instruction_cache(void const *start, std::size_t size)
 #if defined(_WIN32)
 	return FlushInstructionCache(GetCurrentProcess(), start, size) != 0;
 #else
-#if !defined(SDLMAME_EMSCRIPTEN)
+#if !defined(SDLMAME_EMSCRIPTEN) && !defined(TARGET_OS_IPHONE)
 	char const *const begin(reinterpret_cast<char const *>(start));
 	char const *const end(begin + size);
 	__builtin___clear_cache(const_cast<char *>(begin), const_cast<char *>(end));


### PR DESCRIPTION
Add the iOS-arm64 platform to Makefile.libretro and set some needed flags.

Add platform specific flag for iOS/tvOS called `TARGET_OS_IPHONE`, consistent with Apple's target conditional macros, and pass it along to the compile process.

Disable the `invalidate_instruction_cache` capability for iOS/tvOS - I heard this is related to JIT and it's not readily supported in iOS.