### PR TITLE
retro_finish() when started empty

### DIFF
--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -337,7 +337,7 @@ void mame_machine_manager::mmchange()
       if (retro_global_machine->exit_pending())m_options.set_system_name("");
    }
 
-   if (!started_empty || (system == &GAME_NAME(___empty)) )
+   if (mfirst == 0)
       retro_finish();
 
 }

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -337,9 +337,8 @@ void mame_machine_manager::mmchange()
       if (retro_global_machine->exit_pending())m_options.set_system_name("");
    }
 
-   //FIXME RETRO
-   //if (retro_global_machine->exit_pending() && (!started_empty || (system == &GAME_NAME(___empty))))
-   //exit_pending = true;
+   if (!started_empty || (system == &GAME_NAME(___empty)) )
+      retro_finish();
 
 }
  


### PR DESCRIPTION
This would need tested, maybe completely wrong as I don't use this core and not familiar with the code. It appears the code calls an empty driver / game to start to bypass a crash. I think we'd want to close shop if this happens?