### PR TITLE
Remove 1 frame of input lag Fixes libretro/mame#53

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -1449,6 +1449,11 @@ void running_machine::retro_machineexit(){
 
 void running_machine::retro_loop(){
 
+	// get most recent input now 
+	m_manager.osd().input_update();
+	// perform tasks for this frame
+	call_notifiers(MACHINE_NOTIFY_FRAME);
+
 	while (RLOOP==1) {
 
 		// execute CPUs if not paused

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -243,15 +243,19 @@ void video_manager::frame_update(bool from_debugger)
 	if (!from_debugger && !skipped_it && phase > machine_phase::INIT && m_low_latency && effective_throttle())
 		update_throttle(current_time);
 
+#if !defined(__LIBRETRO__)
 	// get most recent input now
 	machine().osd().input_update();
+#endif
 
 	emulator_info::periodic_check();
 
 	if (!from_debugger)
 	{
+#if !defined(__LIBRETRO__)
 		// perform tasks for this frame
 		machine().call_notifiers(MACHINE_NOTIFY_FRAME);
+#endif
 
 		// update frameskipping
 		if (phase > machine_phase::INIT)

--- a/src/osd/libretro/video.cpp
+++ b/src/osd/libretro/video.cpp
@@ -120,6 +120,8 @@ void retro_osd_interface::update(bool skip_redraw)
 	// if we're running, disable some parts of the debugger
  	if ((machine().debug_flags & DEBUG_FLAG_OSD_ENABLED) != 0)
 		debugger_update();
+
+	RLOOP=0;
 }
 
 //============================================================
@@ -131,8 +133,6 @@ void retro_osd_interface::input_update()
 	process_events_buf();
 	poll_inputs(machine());
 	check_osd_inputs(machine());
-
-	RLOOP=0;
 }
 
 //============================================================


### PR DESCRIPTION
addresses this issue:
https://github.com/libretro/mame/issues/53
and as described here:
https://forums.libretro.com/t/strange-behavior-in-mame-lag-control/35082/49

as simple as this fix turned out to be this was a REAL pita to nail down and sort out due to mame's convoluted class interface design.  had to resort to #ifdef'ing out 2 lines in a previously untouched mame core emu source file tho, which for 1 of those lines i just can't think of any better way to do it.  thoughts?