### PR TITLE
Lightgun offscreen adjustments

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -41,6 +41,7 @@ char RPATH[512];
 
 static char option_mouse[50];
 static char option_lightgun[50];
+static char option_lightgun_offscreen[50];
 static char option_cheats[50];
 static char option_overclock[50];
 static char option_renderer[50];
@@ -143,6 +144,7 @@ void retro_set_environment(retro_environment_t cb)
 {
    sprintf(option_mouse, "%s_%s", core, "mouse_enable");
    sprintf(option_lightgun, "%s_%s", core, "lightgun_mode");
+   sprintf(option_lightgun_offscreen, "%s_%s", core, "lightgun_offscreen_mode");
    sprintf(option_cheats, "%s_%s", core, "cheats_enable");
    sprintf(option_overclock, "%s_%s", core, "cpu_overclock");
    sprintf(option_renderer,"%s_%s",core,"alternate_renderer");
@@ -170,6 +172,7 @@ void retro_set_environment(retro_environment_t cb)
     { option_auto_save, "Auto save/load states; disabled|enabled" },
     { option_mouse, "Enable in-game mouse; disabled|enabled" },
     { option_lightgun, "Lightgun mode; none|touchscreen|lightgun" },
+    { option_lightgun_offscreen, "Lightgun offscreen position; free|fixed (top left)|fixed (bottom right)" },
     { option_buttons_profiles, "Profile Buttons according to games (Restart); enabled|disabled" },
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
@@ -249,6 +252,19 @@ static void check_variables(void)
          lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_LIGHTGUN;
       else
          lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_DISABLED;
+   }
+
+   var.key   = option_lightgun_offscreen;
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "free"))
+         lightgun_offscreen_mode = 0;
+      else if (!strcmp(var.value, "fixed (top left)"))
+         lightgun_offscreen_mode = 1;
+	  else
+         lightgun_offscreen_mode = 2;
    }
 
    var.key   = option_buttons_profiles;

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -63,6 +63,7 @@ extern bool experimental_cmdline;
 extern bool hide_gameinfo;
 extern bool mouse_enable;
 extern int  lightgun_mode;
+extern int  lightgun_offscreen_mode;
 extern bool cheats_enable;
 extern bool alternate_renderer;
 extern bool boot_to_osd_enable;

--- a/src/osd/libretro/libretro-internal/retro_init.cpp
+++ b/src/osd/libretro/libretro-internal/retro_init.cpp
@@ -48,6 +48,7 @@ int mame_reset = -1;
 bool nobuffer_enable = false;
 bool mouse_enable = false;
 int  lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_DISABLED;
+int  lightgun_offscreen_mode = 1;
 bool cheats_enable = false;
 bool alternate_renderer = false;
 bool boot_to_osd_enable = false;

--- a/src/osd/modules/input/input_retro.cpp
+++ b/src/osd/modules/input/input_retro.cpp
@@ -773,11 +773,36 @@ void retro_osd_interface::process_lightgun_state(running_machine &machine)
       lightgunX[j] = gun_x_raw[j] * 2;
       lightgunY[j] = gun_y_raw[j] * 2;
 	   
-      //Place the cursor at screen top left when detected as offscreen or when Gun Reload input activated
-      if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) || input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
+      //Place the cursor at a corner of the screen designated by "Lightgun offscreen position" when the cursor touches a min/max value
+      if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ))
 	  {
-	     lightgunX[j] = -65534;
-	     lightgunY[j] = -65534; 
+		 if (lightgun_offscreen_mode == 1)
+		 {
+		    lightgunX[j] = -65535;
+	        lightgunY[j] = -65535;
+		 }
+		 else if (lightgun_offscreen_mode == 2)
+		 {
+		    lightgunX[j] = 65535;
+	        lightgunY[j] = 65535;
+		 }
+	  }
+
+      //The LIGHTGUN_RELOAD input will fire a shot at the bottom-right corner if "Lightgun offscreen position" is set to "fixed (bottom right)"
+	  //That same input will fire a shot at the top-left corner otherwise
+	  //The reload feature of some games fails at the top-left corner
+      if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
+	  {
+		 if (lightgun_offscreen_mode == 2)
+		 {
+		    lightgunX[j] = 65535;
+	        lightgunY[j] = 65535;
+		 }
+		 else
+		 {
+		    lightgunX[j] = -65535;
+	        lightgunY[j] = -65535;
+		 }
 	  }
    }
 }


### PR DESCRIPTION
This introduces the core option "lightgun offscreen position" that affects how a lightgun device behaves when pointing offscreen. The current behavior is to force the lightgun cursor to be at the top-left corner of the screen whenever the cursor reaches a min or max value along either axis. This works well for ensuring that offscreen reload works for most games, but this behavior is not ideal for a couple of cases:

1. Reload fails in some games in the top-left corner when using the lightgun input. `lethalj` and `invasnab` are two examples. The alternate "fixed (bottom right)" selection in this core option makes reload work in those two games regardless of where a lightgun device is pointed offscreen.

2. Many games do not require offscreen reloading at all. It can be beneficial to not force an offscreen position for these. For example, `gunbustr` requires the user to move the gun side to side to turn, and the current offscreen behavior could lead to the player turning in the wrong direction. The "free" selection in this core option does not force the cursor into any particular position when the lightgun device is pointed offscreen.

It seems like the top-left and bottom-right corners should cover all cases, since each game that involves offscreen reloading should allow reloading to work on at least one edge of the screen.

The `GUN RELOAD` RetroArch input maintains its status as an offscreen-shot button. For the "free" and "fixed (top left)" selections, the shot will be fired at the top left of the screen. A shot will be fired at the bottom right for the "fixed (bottom right)" selection.

**Please feel free to make any changes to this that are deemed necessary. I think that some amount of control by the user over this behavior is beneficial. I am not sure I have the best wording for the core option and its choices or if the code implementation is ideal enough, but as is, it does exactly what is described above.** 