### PR TITLE
Clean up lightgun offscreen logic

### DIFF
--- a/src/osd/modules/input/input_retro.cpp
+++ b/src/osd/modules/input/input_retro.cpp
@@ -770,11 +770,12 @@ void retro_osd_interface::process_lightgun_state(running_machine &machine)
             lightgunstate[j].lightgunBUT[1] = 0x80;
          }
       }
-      lightgunX[j] = gun_x_raw[j] * 2;
-      lightgunY[j] = gun_y_raw[j] * 2;
-	   
+
       //Place the cursor at a corner of the screen designated by "Lightgun offscreen position" when the cursor touches a min/max value
-      if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ))
+      //The LIGHTGUN_RELOAD input will fire a shot at the bottom-right corner if "Lightgun offscreen position" is set to "fixed (bottom right)"
+	  //That same input will fire a shot at the top-left corner otherwise
+	  //The reload feature of some games fails at the top-left corner
+      if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) && !input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ))
 	  {
 		 if (lightgun_offscreen_mode == 1)
 		 {
@@ -786,12 +787,13 @@ void retro_osd_interface::process_lightgun_state(running_machine &machine)
 		    lightgunX[j] = 65535;
 	        lightgunY[j] = 65535;
 		 }
+		 else
+		 {
+            lightgunX[j] = gun_x_raw[j] * 2;
+            lightgunY[j] = gun_y_raw[j] * 2;
+		 }
 	  }
-
-      //The LIGHTGUN_RELOAD input will fire a shot at the bottom-right corner if "Lightgun offscreen position" is set to "fixed (bottom right)"
-	  //That same input will fire a shot at the top-left corner otherwise
-	  //The reload feature of some games fails at the top-left corner
-      if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
+	  else if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) && input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
 	  {
 		 if (lightgun_offscreen_mode == 2)
 		 {
@@ -803,6 +805,24 @@ void retro_osd_interface::process_lightgun_state(running_machine &machine)
 		    lightgunX[j] = -65535;
 	        lightgunY[j] = -65535;
 		 }
+	  }
+	  else if (!input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) && input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
+	  {
+		 if (lightgun_offscreen_mode == 2)
+		 {
+		    lightgunX[j] = 65535;
+	        lightgunY[j] = 65535;
+		 }
+		 else
+		 {
+		    lightgunX[j] = -65535;
+	        lightgunY[j] = -65535;
+		 }
+	  }
+	  else
+	  {
+         lightgunX[j] = gun_x_raw[j] * 2;
+         lightgunY[j] = gun_y_raw[j] * 2;
 	  }
    }
 }


### PR DESCRIPTION
The location of the lightgun cursor depends on where the user's physical device is pointing and if the `GUN RELOAD` input is activated. My previous logic had a few holes for certain situations that I only noticed when testing on Windows. This should close all of those holes. The new logic defines the behavior when:

1. The gun is pointed offscreen and the reload button is NOT being pressed
2. The gun is pointed offscreen and the reload button is being pressed
3. The gun is pointed onscreen and the reload button is being pressed
4. The gun is pointed onscreen and the reload button is NOT being pressed

That should cover all possible cases for all players separately. Sorry for any inconvenience anyone may have experienced previously. As always, feel free to streamline or add anything that you feel may be an improvement.