### PR TITLE
Set frame timing based off m_frame_period.

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -7,6 +7,7 @@
 #include "osdepend.h"
 
 #include "emu.h"
+#include "screen.h"
 #include "emuopts.h"
 #include "render.h"
 #include "ui/uimain.h"
@@ -731,6 +732,15 @@ void retro_run (void)
    else
       video_cb(NULL, fb_width, fb_height, fb_pitch << LOG_PIXEL_BYTES);
 #endif
+   const screen_device *primary_screen = screen_device_enumerator(mame_machine_manager::instance()->machine()->root_device()).first();
+   float current_screen_refresh = primary_screen->frame_period().as_hz();
+   if (current_screen_refresh != retro_fps) {
+      retro_fps = current_screen_refresh;
+      struct retro_system_av_info av_info;
+      retro_get_system_av_info(&av_info);
+
+      environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
+   }
 }
 
 bool retro_load_game(const struct retro_game_info *info)

--- a/src/osd/libretro/window.cpp
+++ b/src/osd/libretro/window.cpp
@@ -399,7 +399,7 @@ int retro_window_info::window_init()
     const screen_device *primary_screen = screen_device_enumerator(machine().root_device()).first();
 
     if (primary_screen != nullptr){
-        retro_fps = ATTOSECONDS_TO_HZ(primary_screen->refresh_attoseconds());
+        retro_fps = primary_screen->frame_period().as_hz();
 	}
 
 	if(alternate_renderer==false){


### PR DESCRIPTION
Upstream derives frame timing from the m_frame_period value in screen.h and not m_refresh as is done in the libretro port.
Also adding a check to see if this value has been updated frame to frame to allow the frontend to update timings.

Should fix #321 