### PR TITLE
Add mamemess core for Android arm64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,6 +196,22 @@ android-arm64-v8a:
     - master
     - /^libretro/mame.*$/
 
+# Android ARMv8a (mess)
+android-arm64-v8a-mess:
+  extends:
+    - .libretro-android-make-arm64-v8a
+    - .core-defs
+  variables:
+    TARGET:    mame
+    SUBTARGET: mess
+    CORENAME:  mamemess
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-android-arm64-v8a-mess"
+  only:
+    - master
+    - /^libretro/mame.*$/
+
 # Android 64-bit x86
 android-x86_64:
   extends:


### PR DESCRIPTION
This should build a full mame-mess core for android arm64. It successfully compiled a v.251 mamemess core locally, tested it on my phone, and can confirm that it generally works. I tried to reproduce the way the CI system works as closely as possible, but someone with access to the CI system should double check that all goes smooth when moving the output files around. I'd be happy to hear back if this is acceptable or needs improvement. If given the green light, I am prepared to PR a core info file to libretro-super (and libretro?) Thanks for looking into this and thanks for the great work! Benjamin