### PR TITLE
Makefile adjustments

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -2,7 +2,7 @@
 VERBOSE ?= 1
 RETRO ?= 1
 NOWERROR ?= 1
-CONFIG ?= libretro"
+CONFIG ?= libretro
 NO_USE_MIDI ?= 1
 NO_USE_PORTAUDIO ?= 1
 PTR64 ?= 1
@@ -104,6 +104,10 @@ ifneq ($(findstring win,$(platform)),)
 	CXX ?= cxx
 	AR  ?= ar
 	PLATFLAGS += TARGETOS="windows" OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)" "AR=$(AR)"
+	LLD := $(shell command -v lld 2> /dev/null)
+	ifneq ($(LLD),)
+		BUILDFLAGS += LDOPTS="-fuse-ld=lld"
+	endif
 	ifneq ($(WINDRES),)
 		PLATFLAGS += WINDRES="$(WINDRES)"
 	endif

--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -59,7 +59,7 @@ end
 	addprojectflags()
 	flags {
 		"NoManifest",
-		"Symbols", -- always include minimum symbols for executables
+		--"Symbols", -- always include minimum symbols for executables, or maybe not, since it wastes space and needs stripping after
 	}
 
 	if _OPTIONS["SYMBOLS"] then


### PR DESCRIPTION
- Use `lld` in Windows instead of `ld` if available for faster linking
- Stop including symbols so no need for stripping
