### PR TITLE
Allow possibility to skip premake scripts once they are done

### DIFF
--- a/3rdparty/genie/src/host/premake.c
+++ b/3rdparty/genie/src/host/premake.c
@@ -107,6 +107,10 @@ int premake_execute(lua_State* L, int argc, const char** argv)
 	/* Parse the command line arguments */
 	int z = process_arguments(L, argc, argv);
 
+	/* Skip doing the scripts every single time */
+	if (!strcmp(getenv("REGENIE"), "0"))
+		return z;
+
 	/* Run the built-in Premake scripts */
 	if (z == OKAY)  z = load_builtin_scripts(L);
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ To build libretro MAME core from source you need to use `Makefile.libretro` make
 make -f Makefile.libretro
 ```
 
+
+For faster building after the initial makefile creation:
+
+```
+make -f Makefile.libretro REGENIE=0
+```
+
+For Windows install `lld` for much faster linking.
+
 --------
 
 # **MAME** #


### PR DESCRIPTION
Further cut down build time for rebuilds by harnessing existing variable `REGENIE=0`.