### PR TITLE
Add core options for joystick deadzone + saturation

### DIFF
--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -355,7 +355,8 @@ void mame_machine_manager::mmchange()
    }
    else
    {
-      if (retro_global_machine->exit_pending())m_options.set_system_name("");
+      if (retro_global_machine->exit_pending())
+         m_options.set_system_name("");
    }
 
    //FIXME RETRO

--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -192,51 +192,49 @@ void retro_set_environment(retro_environment_t cb)
    sprintf(option_mouse, "%s_%s", core, "mouse_enable");
    sprintf(option_lightgun, "%s_%s", core, "lightgun_mode");
    sprintf(option_lightgun_offscreen, "%s_%s", core, "lightgun_offscreen_mode");
-   sprintf(option_cheats, "%s_%s", core, "cheats_enable");
-   sprintf(option_overclock, "%s_%s", core, "cpu_overclock");
-   sprintf(option_renderer,"%s_%s",core,"alternate_renderer");
-   sprintf(option_osd,"%s_%s",core,"boot_to_osd");
-   sprintf(option_bios,"%s_%s",core,"boot_to_bios");
-   sprintf(option_cli,"%s_%s",core,"boot_from_cli");
-   sprintf(option_softlist,"%s_%s",core,"softlists_enable");
-   sprintf(option_softlist_media,"%s_%s",core,"softlists_auto_media");
-   sprintf(option_media,"%s_%s",core,"media_type");
-   sprintf(option_read_config,"%s_%s",core,"read_config");
-   sprintf(option_write_config,"%s_%s",core,"write_config");
-   sprintf(option_auto_save,"%s_%s",core,"auto_save");
-   sprintf(option_saves,"%s_%s",core,"saves");
-   sprintf(option_throttle,"%s_%s",core,"throttle");
-   sprintf(option_res,"%s_%s",core,"altres");
    sprintf(option_buttons_profiles, "%s_%s", core, "buttons_profiles");
-   sprintf(option_mame_paths, "%s_%s", core, "mame_paths_enable");
    sprintf(option_mame_4way, "%s_%s", core, "mame_4way_enable");
+   sprintf(option_renderer, "%s_%s", core, "alternate_renderer");
+   sprintf(option_res, "%s_%s", core, "altres");
+   sprintf(option_overclock, "%s_%s", core, "cpu_overclock");
+   sprintf(option_cheats, "%s_%s", core, "cheats_enable");
+   sprintf(option_throttle, "%s_%s", core, "throttle");
+   sprintf(option_bios, "%s_%s", core, "boot_to_bios");
+   sprintf(option_osd, "%s_%s", core, "boot_to_osd");
+   sprintf(option_cli, "%s_%s", core, "boot_from_cli");
+   sprintf(option_read_config, "%s_%s", core, "read_config");
+   sprintf(option_write_config, "%s_%s", core, "write_config");
+   sprintf(option_mame_paths, "%s_%s", core, "mame_paths_enable");
+   sprintf(option_saves, "%s_%s", core, "saves");
+   sprintf(option_auto_save, "%s_%s", core, "auto_save");
+   sprintf(option_softlist, "%s_%s", core, "softlists_enable");
+   sprintf(option_softlist_media, "%s_%s", core, "softlists_auto_media");
+   sprintf(option_media, "%s_%s", core, "media_type");
 
-   static const struct retro_variable vars[] = {
-    { option_read_config, "Read configuration; disabled|enabled" },
-    { option_write_config, "Write configuration; disabled|enabled" },
-    { option_saves, "Save state naming; game|system" },
-    { option_auto_save, "Auto save/load states; disabled|enabled" },
-    { option_mouse, "Enable in-game mouse; disabled|enabled" },
-    { option_lightgun, "Lightgun mode; none|touchscreen|lightgun" },
-    { option_lightgun_offscreen, "Lightgun offscreen position; free|fixed (top left)|fixed (bottom right)" },
-    { option_buttons_profiles, "Profile Buttons according to games (Restart); enabled|disabled" },
-    { option_throttle, "Enable throttle; disabled|enabled" },
-    { option_cheats, "Enable cheats; disabled|enabled" },
-    { option_overclock, "Main CPU Overclock; default|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|60|65|70|75|80|85|90|95|100|105|110|115|120|125|130|135|140|145|150" },
-    { option_renderer, "Alternate render method; disabled|enabled" },
-
-    { option_softlist, "Enable softlists; enabled|disabled" },
-    { option_softlist_media, "Softlist automatic media type; enabled|disabled" },
-    { option_media, "Media type; rom|cart|flop|cdrm|cass|hard|serl|prin" },
-    { option_bios, "Boot to BIOS; disabled|enabled" },
-
-    { option_osd, "Boot to OSD; disabled|enabled" },
-    { option_cli, "Boot from CLI; disabled|enabled" },
-    { option_res, "Resolution; 640x480|640x360|800x600|800x450|960x720|960x540|1024x768|1024x576|1280x960|1280x720|1600x1200|1600x900|1440x1080|1920x1080|1920x1440|2560x1440|2880x2160|3840x2160" },
-    { option_mame_paths, "MAME INI Paths; disabled|enabled" },
-
-    { option_mame_4way, "MAME Joystick 4-way simulation; disabled|4way|strict|qbert"},
-    { NULL, NULL },
+   static const struct retro_variable vars[] =
+   {
+      { option_mouse, "Enable Mouse; disabled|enabled" },
+      { option_lightgun, "Lightgun Mode; none|touchscreen|lightgun" },
+      { option_lightgun_offscreen, "Lightgun Offscreen Position; free|fixed (top left)|fixed (bottom right)" },
+      { option_buttons_profiles, "Profile Buttons Per Game; enabled|disabled" },
+      { option_mame_4way, "MAME Joystick 4-way Simulation; disabled|4way|strict|qbert"},
+      { option_renderer, "Alternate Render; disabled|enabled" },
+      { option_res, "Alternate Render Resolution; 640x480|640x360|800x600|800x450|960x720|960x540|1024x768|1024x576|1280x960|1280x720|1600x1200|1600x900|1440x1080|1920x1080|1920x1440|2560x1440|2880x2160|3840x2160" },
+      { option_overclock, "Main CPU Overclock; default|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|60|65|70|75|80|85|90|95|100|105|110|115|120|125|130|135|140|145|150" },
+      { option_cheats, "Enable Cheats; disabled|enabled" },
+      { option_throttle, "Enable Throttle; disabled|enabled" },
+      { option_bios, "Boot to BIOS; disabled|enabled" },
+      { option_osd, "Boot to OSD; disabled|enabled" },
+      { option_cli, "Boot from CLI; disabled|enabled" },
+      { option_read_config, "Read Configuration; disabled|enabled" },
+      { option_write_config, "Write Configuration; disabled|enabled" },
+      { option_mame_paths, "MAME INI Paths; disabled|enabled" },
+      { option_saves, "Save State Naming; game|system" },
+      { option_auto_save, "Auto Save/Load States; disabled|enabled" },
+      { option_softlist, "Enable Softlists; enabled|disabled" },
+      { option_softlist_media, "Softlist Automatic Media Type; enabled|disabled" },
+      { option_media, "Media Type; rom|cart|flop|cdrm|cass|hard|serl|prin" },
+      { NULL, NULL },
    };
 
    environ_cb = cb;

--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -524,44 +524,6 @@ static void check_variables(void)
       if (!strcmp(var.value, "qbert"))
          sprintf(mame_4way_map, "%s", "4444s8888.4444s8888.444458888.444555888.ss5.222555666.222256666.2222s6666.2222s6666");
    }
-
-#define input_descriptor_macro(c) \
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "Joy Left" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "Joy Right" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "Joy Up" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "Joy Down" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      "A" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "B" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      "X" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Y" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "L" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "R" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "L2" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,     "L3" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     "R2" },\
-      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     "R3" },\
-      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Stick X" },\
-      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Stick Y" },\
-      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Stick X" },\
-      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Stick Y" },
-
-   struct retro_input_descriptor desc[] =
-   {
-      input_descriptor_macro(0)
-      input_descriptor_macro(1)
-      input_descriptor_macro(2)
-      input_descriptor_macro(3)
-      input_descriptor_macro(4)
-      input_descriptor_macro(5)
-      input_descriptor_macro(6)
-      input_descriptor_macro(7)
-      { 0 },
-   };
-
-   environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
-#undef input_descriptor_macro
 }
 
 unsigned retro_api_version(void)
@@ -667,6 +629,43 @@ void retro_init (void)
       log_cb(RETRO_LOG_ERROR, "pixel format not supported\n");
       exit(0);
    }
+
+   #define input_descriptor_macro(c) \
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "Joy Left" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "Joy Right" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "Joy Up" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "Joy Down" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      "A" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "B" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      "X" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Y" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "L" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "R" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "L2" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,     "L3" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     "R2" },\
+      { c, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     "R3" },\
+      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Stick X" },\
+      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Stick Y" },\
+      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Stick X" },\
+      { c, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Stick Y" },
+
+   struct retro_input_descriptor input_descriptors[] =
+   {
+      input_descriptor_macro(0)
+      input_descriptor_macro(1)
+      input_descriptor_macro(2)
+      input_descriptor_macro(3)
+      input_descriptor_macro(4)
+      input_descriptor_macro(5)
+      input_descriptor_macro(6)
+      input_descriptor_macro(7)
+      { 0 },
+   };
+   #undef input_descriptor_macro
+   environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, input_descriptors);
 
    init_output_audio_buffer(2048);
 }

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -84,6 +84,8 @@ extern bool buttons_profiles;
 extern bool mame_paths_enable;
 extern bool mame_4way_enable;
 extern char mame_4way_map[256];
+extern char joystick_deadzone[8];
+extern char joystick_saturation[8];
 
 extern bool res_43;
 extern bool video_changed;

--- a/src/osd/libretro/libretro-internal/retro_init.cpp
+++ b/src/osd/libretro/libretro-internal/retro_init.cpp
@@ -157,37 +157,7 @@ static int parsePath(char* path, char* gamePath, char* gameName)
 static int parseSystemName(char* path, char* systemName)
 {
    int i, j = 0;
-   int slashIndex[2]={-1,-1};
-   int len = strlen(path);
-
-   if (len < 1)
-      return 0;
-
-   for (i = len - 1; i >=0; i--)
-   {
-      if (j<2)
-      {
-         if (path[i] == slash)
-         {
-            slashIndex[j] = i;
-            j++;
-         }
-      }
-      else
-         break;
-   }
-
-   if (slashIndex[0] < 0 || slashIndex[1] < 0 )
-      return 0;
-
-   strncpy(systemName, path + (slashIndex[1] +1), slashIndex[0]-slashIndex[1]-1);
-   return 1;
-}
-
-static int parseParentPath(char* path, char* parentPath)
-{
-   int i, j = 0;
-   int slashIndex[2] = {-1,-1};
+   int slashIndex[2] = {-1, -1};
    int len = strlen(path);
 
    if (len < 1)
@@ -195,7 +165,7 @@ static int parseParentPath(char* path, char* parentPath)
 
    for (i = len - 1; i >= 0; i--)
    {
-      if (j<2)
+      if (j < 2)
       {
          if (path[i] == slash)
          {
@@ -207,7 +177,37 @@ static int parseParentPath(char* path, char* parentPath)
          break;
    }
 
-   if (slashIndex[0] < 0 || slashIndex[1] < 0 )
+   if (slashIndex[0] < 0 || slashIndex[1] < 0)
+      return 0;
+
+   strncpy(systemName, path + (slashIndex[1] + 1), slashIndex[0] - slashIndex[1] - 1);
+   return 1;
+}
+
+static int parseParentPath(char* path, char* parentPath)
+{
+   int i, j = 0;
+   int slashIndex[2] = {-1, -1};
+   int len = strlen(path);
+
+   if (len < 1)
+      return 0;
+
+   for (i = len - 1; i >= 0; i--)
+   {
+      if (j < 2)
+      {
+         if (path[i] == slash)
+         {
+            slashIndex[j] = i;
+            j++;
+         }
+      }
+      else
+         break;
+   }
+
+   if (slashIndex[0] < 0 || slashIndex[1] < 0)
       return 0;
 
    strncpy(parentPath, path, slashIndex[1]);
@@ -605,84 +605,81 @@ static int execute_game_cmd(char* path)
 {
    unsigned i;
    int driverIndex;
-   int gameRot=0;
+   int gameRot     = 0;
    bool CreateConf = (!strcmp(ARGUV[0],"-cc") || !strcmp(ARGUV[0],"-createconfig")) ? 1 : 0;
    bool Only1Arg   = (ARGUC == 1) ? 1 : 0;
    bool Mamecmdopt = strcmp(ARGUV[0],core) == 0 ? 1: 0;
 
-if(!Only1Arg)CreateConf = (!strcmp(ARGUV[1],"-cc") || !strcmp(ARGUV[1],"-createconfig")) ? 1 : 0;
-if (log_cb)log_cb(RETRO_LOG_INFO,"ARGUV[0]=%s\n",ARGUV[0]);
+   if (!Only1Arg)
+      CreateConf = (!strcmp(ARGUV[1],"-cc") || !strcmp(ARGUV[1],"-createconfig")) ? 1 : 0;
+
+   log_cb(RETRO_LOG_INFO, "ARGUV[0]=%s\n", ARGUV[0]);
 
    FirstTimeUpdate = 1;
 
    screenRot = 0;
 
    for (i = 0; i < 64; i++)
-      xargv_cmd[i]=NULL;
+      xargv_cmd[i] = NULL;
 
    /* split the path to directory and the name without the zip extension */
    if (parsePath(Only1Arg?path:ARGUV[ARGUC-1], MgamePath, MgameName) == 0)
    {
-      if (log_cb)
-      log_cb(RETRO_LOG_ERROR, "parse path failed! path=%s.\n", path);
-      strcpy(MgameName,path );
+      log_cb(RETRO_LOG_ERROR, "parse path failed! path=\"%s\"\n", path);
+      strcpy(MgameName, path);
    }
 
-   if(Only1Arg)
+   if (Only1Arg)
    {
       /* split the path to directory and the name without the zip extension */
       if (parseSystemName(path, MsystemName) ==0)
       {
-         if (log_cb)
-            log_cb(RETRO_LOG_ERROR, "parse systemname failed! path=%s\n", path);
-         strcpy(MsystemName,path );
+         log_cb(RETRO_LOG_ERROR, "parse systemname failed! path=\"%s\"\n", path);
+         strcpy(MsystemName, path);
       }
    }
 
    /* Find the game info. Exit if game driver was not found. */
-   if (getGameInfo(Only1Arg?MgameName:ARGUV[0], &gameRot, &driverIndex,&arcade) == 0)
+   if (getGameInfo(Only1Arg?MgameName:ARGUV[0], &gameRot, &driverIndex, &arcade) == 0)
    {
       /* handle -cc/-createconfig case */
-      if(CreateConf)
+      if (CreateConf)
       {
-         if (log_cb)
-            log_cb(RETRO_LOG_INFO, "Create an %s config\n", core);
+         log_cb(RETRO_LOG_INFO, "Create \"%s\" config\n", core);
       }
       else
       {
-         if (log_cb)
-            log_cb(RETRO_LOG_WARN, "Game not found: %s\n", MgameName);
+         log_cb(RETRO_LOG_WARN, "Game not found: \"%s\"\n", MgameName);
 
-         if(Only1Arg)
+         if (Only1Arg)
          {
             //test if system exist (based on parent path)
-            if (getGameInfo(MsystemName, &gameRot, &driverIndex,&arcade) == 0)
+            if (getGameInfo(MsystemName, &gameRot, &driverIndex, &arcade) == 0)
             {
-               if (log_cb)
-                  log_cb(RETRO_LOG_ERROR, "Driver not found: %s\n", MsystemName);
-                if(!Mamecmdopt)return -2;
+               log_cb(RETRO_LOG_ERROR, "Driver not found: \"%s\"\n", MsystemName);
+               if (!Mamecmdopt)
+                  return -2;
             }
          }
          else
-             if(!Mamecmdopt)return -2;
+             if (!Mamecmdopt)
+                return -2;
       }
    }
 
-   if(Only1Arg)
+   if (Only1Arg)
    {
       /* handle case where Arcade game exist and game on a System also */
-      if(arcade==true)
+      if (arcade==true)
       {
          /* test system */
-         if (getGameInfo(MsystemName, &gameRot, &driverIndex,&arcade) == 0)
+         if (getGameInfo(MsystemName, &gameRot, &driverIndex, &arcade) == 0)
          {
-            if (log_cb)
-               log_cb(RETRO_LOG_ERROR, "System not found: %s\n", MsystemName);
+            log_cb(RETRO_LOG_ERROR, "System not found: \"%s\"\n", MsystemName);
          }
          else
          {
-            if (log_cb)
-               log_cb(RETRO_LOG_INFO, "System found: %s\n", MsystemName);
+            log_cb(RETRO_LOG_INFO, "System found: \"%s\"\n", MsystemName);
             arcade=false;
          }
       }
@@ -691,36 +688,37 @@ if (log_cb)log_cb(RETRO_LOG_INFO,"ARGUV[0]=%s\n",ARGUV[0]);
    Set_Default_Option();
 
    Add_Option("-mouse");
-
    Add_Option("-multimouse");
 
    Set_Path_Option();
 
-   if(Only1Arg)
+   if (Only1Arg)
    {
       /* Assume arcade/mess rom with full path or -cc   */
-      if(CreateConf)
+      if (CreateConf)
          Add_Option((char*)"-createconfig");
       else
       {
          Add_Option((char*)"-rp");
          Add_Option((char*)g_rom_dir);
          log_cb(RETRO_LOG_DEBUG, "System: %s, game: %s\n", MsystemName, MgameName);
+
          int num = driver_list::find(MsystemName);
 
-         if(!arcade && (num != -1) && (strcmp(MsystemName, MgameName) != 0))
+         if (!arcade && (num != -1) && (strcmp(MsystemName, MgameName) != 0))
             Add_Option(MsystemName);
          Add_Option(MgameName);
       }
    }
-   else if (Mamecmdopt){
-         for(i = 1;i < ARGUC; i++)
-            Add_Option(ARGUV[i]);
+   else if (Mamecmdopt)
+   {
+      for (i = 1; i < ARGUC; i++)
+         Add_Option(ARGUV[i]);
    }
    else
    {
       /* Pass all cmdline args */
-      for(i = 0;i < ARGUC; i++)
+      for (i = 0; i < ARGUC; i++)
          Add_Option(ARGUV[i]);
    }
 
@@ -733,20 +731,20 @@ static char CMDFILE[512];
 
 int loadcmdfile(char *argv)
 {
-  std::ifstream cmdfile(argv);
-  std::string cmdstr;
+   std::ifstream cmdfile(argv);
+   std::string cmdstr;
 
-  if(cmdfile.is_open()){
+   if (cmdfile.is_open())
+   {
+      std::getline(cmdfile, cmdstr);
+      cmdfile.close();
 
-    std::getline(cmdfile, cmdstr);
-    cmdfile.close();
+      sprintf(CMDFILE, "%s", cmdstr.c_str());
 
-    sprintf(CMDFILE, "%s", cmdstr.c_str());
+      return 1;
+   }
 
-    return 1;
-  }
-
-  return 0;
+   return 0;
 }
 
 
@@ -757,60 +755,68 @@ extern "C"
 */
 int mmain2(int argc, const char *argv)
 {
-   unsigned i=0;
+   unsigned i = 0;
+   int result = 0;
    osd_options options;
    //cli_options MRoptions;
-   int result = 0;
 
-   strcpy(gameName,argv);
+   strcpy(gameName, argv);
 
    // handle cmd file
-   if (strlen(gameName) >= strlen("cmd")){
-           if(!core_stricmp(&gameName[strlen(gameName)-strlen("cmd")], "cmd"))
-                       i=loadcmdfile(gameName);
+   if (strlen(gameName) >= strlen("cmd"))
+   {
+      if(!core_stricmp(&gameName[strlen(gameName)-strlen("cmd")], "cmd"))
+         i = loadcmdfile(gameName);
    }
 
-   if(i==1)
+   if (i == 1)
    {
       parse_cmdline(CMDFILE);
-      if (log_cb)
-         log_cb(RETRO_LOG_INFO, "Starting game from command line: %s\n",CMDFILE);
-
+      log_cb(RETRO_LOG_INFO, "Starting game from command line: \"%s\"\n", CMDFILE);
       result = execute_game_cmd(ARGUV[ARGUC-1]);
-
    }
    else
-   if(experimental_cmdline)
+   if (experimental_cmdline)
    {
       parse_cmdline(argv);
-      if (log_cb)
-         log_cb(RETRO_LOG_INFO, "Starting game from command line: %s\n",gameName);
-
+      log_cb(RETRO_LOG_INFO, "Starting game from command line: \"%s\"\n",gameName);
       result = execute_game_cmd(ARGUV[ARGUC-1]);
    }
    else
    {
-      if (log_cb)
-         log_cb(RETRO_LOG_INFO, "Starting game: %s\n",gameName);
+      log_cb(RETRO_LOG_INFO, "Starting game: \"%s\"\n", gameName);
       result = execute_game(gameName);
    }
 
    if (result < 0)
       return result;
 
-   if (log_cb)
-      log_cb(RETRO_LOG_DEBUG, "Parameters:\n");
+   log_cb(RETRO_LOG_DEBUG, "Parameters:\n");
+   char parameter_output[255];
 
    for (i = 0; i < PARAMCOUNT; i++)
    {
+      const char* nextarg = (XARGV[i+1][0]) ? XARGV[i+1] : NULL;
+
       xargv_cmd[i] = (char*)(XARGV[i]);
-      if (log_cb)
-         log_cb(RETRO_LOG_DEBUG, " %s\n",XARGV[i]);
+
+      if (i > 0 && XARGV[i][0] != '-' && nextarg)
+      {
+         strcat(parameter_output, " ");
+         strcat(parameter_output, XARGV[i]);
+         nextarg = NULL;
+      }
+      else
+         strcpy(parameter_output, XARGV[i]);
+
+      if (nextarg && nextarg[0] != '-')
+         continue;
+
+      log_cb(RETRO_LOG_DEBUG, "  %s\n", parameter_output);
    }
 
-
-   //launch mmain from retromain
-   result=mmain(PARAMCOUNT, ( char **)xargv_cmd);
+   // launch mmain from retromain
+   result = mmain(PARAMCOUNT, (char **)xargv_cmd);
 
    xargv_cmd[PARAMCOUNT - 2] = NULL;
 

--- a/src/osd/libretro/retromain.cpp
+++ b/src/osd/libretro/retromain.cpp
@@ -211,14 +211,14 @@ int mmain(int argc, char *argv[])
 #endif
 
 	{
-		retro_global_osd =  new retro_osd_interface(retro_global_options);
+		retro_global_osd = new retro_osd_interface(retro_global_options);
 
 		retro_output retrooutput;
 		osd_output::push(&retrooutput);
 
 		retro_global_osd->register_options();
 
-		res =  emulator_info::start_frontend(retro_global_options, *retro_global_osd,args);
+		res = emulator_info::start_frontend(retro_global_options, *retro_global_osd,args);
 		
 		osd_output::pop(&retrooutput);
 		

--- a/src/osd/libretro/window.cpp
+++ b/src/osd/libretro/window.cpp
@@ -522,9 +522,8 @@ void retro_window_info::update()
 				view_aspect = retro_aspect;
 				monitor()->refresh();
 				monitor()->update_resolution(tempwidth, tempheight);
-				//osd_printf_info("(%dx%d)as:%f rot:%d %d\n",tempwidth, tempheight,retro_aspect,target()->orientation(),target()->orientation() & ORIENTATION_SWAP_XY);
 
-				if (fb_width>max_width || fb_height>max_height)
+				if (fb_width > max_width || fb_height > max_height)
 					NEWGAME_FROM_OSD = 1;
 				else
 					NEWGAME_FROM_OSD = (NEWGAME_FROM_OSD == 1) ? 1 : 2;

--- a/src/osd/modules/input/input_retro.cpp
+++ b/src/osd/modules/input/input_retro.cpp
@@ -875,7 +875,7 @@ public:
 
 	virtual void input_init(running_machine &machine) override
 	{
-		auto &devinfo = devicelist().create_device<retro_keyboard_device>(machine, "Retro Keyboard 1", "Retro Keyboard 1", *this);
+		auto &devinfo = devicelist().create_device<retro_keyboard_device>(machine, "RetroKeyboard0", "RetroKeyboard0", *this);
 
 		int i;
    		for(i = 0; i < RETROK_LAST; i++){
@@ -969,7 +969,7 @@ public:
 		
 		for(i = 0; i < 8; i++)
 		{
-		   sprintf(defname, "Retro mouse%d", i);
+		   sprintf(defname, "RetroMouse%d", i);
 		   
 		   auto &devinfo = devicelist().create_device<retro_mouse_device>(machine, defname, defname, *this);
 
@@ -1217,7 +1217,7 @@ public:
 		
 		for(i = 0; i < 8; i++)
 		{
-		   sprintf(defname, "Retro lightgun%d", i);
+		   sprintf(defname, "RetroLightgun%d", i);
 
 		   auto &devinfo = devicelist().create_device<retro_lightgun_device>(machine, defname, defname, *this);
 

--- a/src/osd/modules/input/input_retro.cpp
+++ b/src/osd/modules/input/input_retro.cpp
@@ -635,7 +635,7 @@ void retro_osd_interface::process_mouse_state(running_machine &machine)
 	     int mouse_m[8];
          int16_t mouse_x[8];
          int16_t mouse_y[8];
-         //printf("mouseneable=%d\n",mouse_enable);
+
          if (!mouse_enable)
             return;
 
@@ -732,7 +732,6 @@ void retro_osd_interface::process_mouse_state(running_machine &machine)
             mbM[i]=0;
          }
    }
-	      //printf("vm(%d,%d) mc(%d,%d) mr(%d,%d)\n",vmx,vmy,mouse_x[0],mouse_y[0],mouseLX[0],mouseLY[0]);
 }
 
 void retro_osd_interface::process_lightgun_state(running_machine &machine)


### PR DESCRIPTION
The default hardcoded analog stick deadzone of `0` is pretty horrible with gamepads, therefore a core option is the best route with a reasonable default of `0.20`. Also a bunch of cleanups.
