### PR TITLE
Use libretro screen rotation

### DIFF
--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -502,6 +502,10 @@ void video_manager::exit()
 	machine().render().target_free(m_snap_target);
 	m_snap_bitmap.reset();
 
+#ifdef __LIBRETRO__
+	return;
+#endif
+
 	// print a final result if we have at least 2 seconds' worth of data
 	if (!emulator_info::standalone() && m_overall_emutime.seconds() >= 1)
 	{

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -55,7 +55,7 @@ enum
    RETRO_SETTING_LIGHTGUN_MODE_LIGHTGUN
 };
 
-extern int NEWGAME_FROM_OSD;
+extern int video_changed;
 extern int retro_pause;
 extern char g_rom_dir[1024];
 extern const char *retro_save_directory;
@@ -87,9 +87,6 @@ extern char mame_4way_map[256];
 extern char joystick_deadzone[8];
 extern char joystick_saturation[8];
 
-extern bool res_43;
-extern bool video_changed;
-
 extern int mouseLX[8];
 extern int mouseLY[8];
 extern int mouseBUT[4];
@@ -108,7 +105,6 @@ extern int ui_ipt_pushchar;
 
 extern int fb_width;
 extern int fb_height;
-extern int fb_pitch;
 extern int max_width;
 extern int max_height;
 extern float retro_aspect;

--- a/src/osd/modules/monitor/monitor_retro.cpp
+++ b/src/osd/modules/monitor/monitor_retro.cpp
@@ -28,13 +28,12 @@ public:
 private:
 	void refresh() override
 	{
-
 		m_pos_size = osd_rect(0,0, fb_width, fb_height);
 		m_usuable_pos_size = osd_rect(0,0, fb_width, fb_height);
 		m_is_primary = (oshandle() == 0);
 
 		if (!alternate_renderer)
-		    set_aspect(retro_aspect);
+		    set_aspect(view_aspect);
 	}
 };
 
@@ -91,7 +90,7 @@ protected:
 		{
 			int i;
 
-			osd_printf_verbose("Enter init_monitors\n");
+			//osd_printf_verbose("Enter init_monitors\n");
 
 			for (i = 0; i < 1; i++)
 			{
@@ -101,8 +100,12 @@ protected:
 				// allocate a new monitor info
 				std::shared_ptr<osd_monitor_info> monitor = std::make_shared<retro_monitor_info>(*this, i, temp, 1.0f);
 
-				osd_printf_verbose("Adding monitor %s (%d x %d)\n", monitor->devicename().c_str(),
-				monitor->position_size().width(), monitor->position_size().height());
+				/*
+				osd_printf_verbose("Adding monitor %s (%d x %d)\n",
+				      monitor->devicename().c_str(),
+				      monitor->position_size().width(),
+				      monitor->position_size().height());
+				*/
 
 				// guess the aspect ratio assuming square pixels
 				monitor->set_aspect(static_cast<float>(monitor->position_size().width()) / static_cast<float>(monitor->position_size().height()));
@@ -111,7 +114,7 @@ protected:
 				add_monitor(monitor);
 			}
 		}
-		osd_printf_verbose("Leave init_monitors\n");
+		//osd_printf_verbose("Leave init_monitors\n");
 
 		return 0;
 	}


### PR DESCRIPTION
Offload rotation to frontend if allowed with `video_allow_rotate`. Also fixed alternate renderer for seamless toggling and for it to not trigger video change on any option change, and cleaned up unused and unnecessary stuff.

Closes #261 
Closes #234 
