### PR TITLE
Fix premake skip trick

### DIFF
--- a/3rdparty/genie/src/host/premake.c
+++ b/3rdparty/genie/src/host/premake.c
@@ -106,9 +106,10 @@ int premake_execute(lua_State* L, int argc, const char** argv)
 {
 	/* Parse the command line arguments */
 	int z = process_arguments(L, argc, argv);
+	const char* env = getenv("PREMAKE");
 
 	/* Skip doing the scripts every single time */
-	if (!strcmp(getenv("REGENIE"), "0"))
+	if (env && !strcmp(env, "0"))
 		return z;
 
 	/* Run the built-in Premake scripts */

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ make -f Makefile.libretro
 For faster building after the initial makefile creation:
 
 ```
-make -f Makefile.libretro REGENIE=0
+make -f Makefile.libretro PREMAKE=0
 ```
 
 For Windows install `lld` for much faster linking.


### PR DESCRIPTION
Changed the variable from `REGENIE` to an unused `PREMAKE`.
