### PR TITLE
Add rotation mode core option

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -45,26 +45,27 @@ static int cpu_overclock = 100;
 static char option_mouse[50];
 static char option_lightgun[50];
 static char option_lightgun_offscreen[50];
-static char option_cheats[50];
-static char option_overclock[50];
+static char option_buttons_profiles[50];
+static char option_joystick_deadzone[50];
+static char option_joystick_saturation[50];
+static char option_mame_4way[50];
+static char option_rotation_mode[50];
 static char option_renderer[50];
+static char option_res[50];
+static char option_overclock[50];
+static char option_cheats[50];
+static char option_throttle[50];
+static char option_bios[50];
 static char option_osd[50];
 static char option_cli[50];
-static char option_bios[50];
+static char option_read_config[50];
+static char option_write_config[50];
+static char option_mame_paths[50];
+static char option_saves[50];
+static char option_auto_save[50];
 static char option_softlist[50];
 static char option_softlist_media[50];
 static char option_media[50];
-static char option_read_config[50];
-static char option_write_config[50];
-static char option_auto_save[50];
-static char option_throttle[50];
-static char option_saves[50];
-static char option_buttons_profiles[50];
-static char option_mame_paths[50];
-static char option_mame_4way[50];
-static char option_res[50];
-static char option_joystick_deadzone[50];
-static char option_joystick_saturation[50];
 
 const char *retro_save_directory;
 const char *retro_system_directory;
@@ -197,6 +198,7 @@ void retro_set_environment(retro_environment_t cb)
    sprintf(option_joystick_deadzone, "%s_%s", core, "joystick_deadzone");
    sprintf(option_joystick_saturation, "%s_%s", core, "joystick_saturation");
    sprintf(option_mame_4way, "%s_%s", core, "mame_4way_enable");
+   sprintf(option_rotation_mode, "%s_%s", core, "rotation_mode");
    sprintf(option_renderer, "%s_%s", core, "alternate_renderer");
    sprintf(option_res, "%s_%s", core, "altres");
    sprintf(option_overclock, "%s_%s", core, "cpu_overclock");
@@ -223,6 +225,7 @@ void retro_set_environment(retro_environment_t cb)
       { option_joystick_deadzone, "Joystick Deadzone; 0.20|0.0|0.05|0.10|0.15|0.20|0.25|0.30|0.35|0.40|0.45|0.50|0.55|0.60|0.65|0.70|0.75|0.80|0.85|0.90|0.95|1.00" },
       { option_joystick_saturation, "Joystick Saturation; 1.00|0.05|0.10|0.15|0.20|0.25|0.30|0.35|0.40|0.45|0.50|0.55|0.60|0.65|0.70|0.75|0.80|0.85|0.90|0.95|1.00" },
       { option_mame_4way, "Joystick 4-way Simulation; disabled|4way|strict|qbert"},
+      { option_rotation_mode, "Rotation Mode; libretro|internal|none" },
       { option_renderer, "Alternate Renderer; disabled|enabled" },
       { option_res, "Alternate Renderer Resolution; 640x480|640x360|800x600|800x450|960x720|960x540|1024x768|1024x576|1280x960|1280x720|1600x1200|1600x900|1440x1080|1920x1080|1920x1440|2560x1440|2880x2160|3840x2160" },
       { option_overclock, "Main CPU Overclock; default|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|60|65|70|75|80|85|90|95|100|105|110|115|120|125|130|135|140|145|150" },
@@ -379,6 +382,19 @@ static void check_variables(void)
       cpu_overclock = 100;
       if (strcmp(var.value, "default"))
         cpu_overclock = atoi(var.value);
+   }
+
+   var.key   = option_rotation_mode;
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "libretro"))
+         rotation_mode = 2;
+      else if (!strcmp(var.value, "internal"))
+         rotation_mode = 1;
+      else
+         rotation_mode = 0;
    }
 
    var.key   = option_renderer;
@@ -776,7 +792,6 @@ bool retro_load_game(const struct retro_game_info *info)
    char basename[256];
 
    check_variables();
-
 
 //FIXME: re-add way to handle OGL
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -57,7 +57,10 @@ enum
 
 extern int video_changed;
 extern int retro_pause;
+extern int mame_reset;
+extern int ui_ipt_pushchar;
 extern char g_rom_dir[1024];
+extern char mediaType[10];
 extern const char *retro_save_directory;
 extern const char *retro_system_directory;
 extern const char *retro_content_directory;
@@ -97,19 +100,12 @@ extern int lightgunBUT[4];
 
 extern unsigned short retrokbd_state[RETROK_LAST];
 
-extern char mediaType[10];
-
-extern int mame_reset;
-
-extern int ui_ipt_pushchar;
-
 extern int fb_width;
 extern int fb_height;
-extern int max_width;
-extern int max_height;
 extern float retro_aspect;
 extern float retro_fps;
 extern float view_aspect;
+extern int rotation_mode;
 static const char core[] = "mame";
 
 /* libretro callbacks */


### PR DESCRIPTION
Rotation and mirroring issues should be gone now with a core option that allows going back to internal rotation, and also an option to skip rotation and go raw. Default mode is `libretro`. Internal rotation can still be used with `libretro` rotation. Let me know if I missed something.

Addition to #360
