### PR TITLE
Fix build version in core info

### DIFF
--- a/makefile
+++ b/makefile
@@ -1076,7 +1076,7 @@ else
 OLD_GIT_VERSION := $(shell cat $(GENDIR)/git_desc 2> NUL)
 endif
 ifneq ($(IGNORE_GIT),1)
-NEW_GIT_VERSION := $(shell git describe --dirty)
+NEW_GIT_VERSION := $(shell git describe --always)
 else
 NEW_GIT_VERSION := unknown
 endif

--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -579,7 +579,7 @@ void retro_get_system_info(struct retro_system_info *info)
    memset(info, 0, sizeof(*info));
 
    info->library_name     = "MAME";
-   info->library_version  = bare_build_version;
+   info->library_version  = build_version;
    info->valid_extensions = "chd|cmd|zip|7z";
    info->need_fullpath    = true;
    info->block_extract    = true;


### PR DESCRIPTION
Since `git describe --dirty` returns
```
fatal: No names found, cannot describe anything.
```
let's make it show the commit hash, and include it in `library_version`.

Currently `library_version` won't show in the menu though because the info file core name won't match with the running `library_name`, but will fix soon.
