### PR TITLE
AV info rework

### DIFF
--- a/src/emu/screen.cpp
+++ b/src/emu/screen.cpp
@@ -21,6 +21,9 @@
 
 #include <set>
 
+#ifdef __LIBRETRO__
+#include "libretro/osdretro.h"
+#endif
 
 //**************************************************************************
 //  DEBUGGING
@@ -1025,6 +1028,10 @@ void screen_device::configure(int width, int height, const rectangle &visarea, a
 
 	// adjust speed if necessary
 	machine().video().update_refresh_speed();
+
+#ifdef __LIBRETRO__
+	retro_fps = ATTOSECONDS_TO_HZ(frame_period);
+#endif
 }
 
 

--- a/src/osd/libretro/osdretro.h
+++ b/src/osd/libretro/osdretro.h
@@ -7,6 +7,12 @@
 
 #include "libretro-internal/libretro_shared.h"
 
+extern float sound_timer;
+extern float retro_fps;
+extern int video_changed;
+extern int rotation_allow;
+
+
 //============================================================
 //  Defines
 //============================================================


### PR DESCRIPTION
A better method for adjusting the internal sound update timer. Also limited the need for `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` calls by getting the proper `retro_fps` already in startup. And moved the backup fps watch out of `retro_run()`.
