### PR TITLE
Geometry corrections

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -28,8 +28,8 @@ bool libretro_supports_bitmasks = false;
 
 int fb_width       = 640;
 int fb_height      = 480;
-int max_width      = 3840;
-int max_height     = 2160;
+int max_width      = fb_width;
+int max_height     = fb_height;
 float retro_aspect = (float)4.0f / (float)3.0f;
 float view_aspect  = 1.0f;
 float retro_fps    = 60.0;

--- a/src/osd/libretro/window.cpp
+++ b/src/osd/libretro/window.cpp
@@ -36,6 +36,9 @@
 #include "modules/render/drawretro.h"
 #include "modules/monitor/monitor_common.h"
 
+extern int max_width;
+extern int max_height;
+extern bool retro_load_ok;
 
 //============================================================
 //  PARAMETERS
@@ -523,6 +526,29 @@ void retro_window_info::update()
 				if (rotation_allow
 						&& (machine().system().flags & ORIENTATION_SWAP_XY))
 					retro_aspect = 1.0f / retro_aspect;
+
+				/* Enlarge maximum geometry always */
+				if (fb_width > max_width || fb_height > max_height)
+				{
+					max_width     = fb_width;
+					max_height    = fb_height;
+					video_changed = 1;
+				}
+
+				/* Shrink geometry to native in native resolution renderer */
+				if (!alternate_renderer)
+				{
+					if (fb_width < max_width || fb_height < max_height)
+					{
+						max_width     = fb_width;
+						max_height    = fb_height;
+						video_changed = 1;
+					}
+				}
+
+				/* No reason to call av_info when not yet running */
+				if (!retro_load_ok)
+					video_changed = 0;
 			}
 
 			if (!this->m_fullscreen)

--- a/src/osd/libretro/window.cpp
+++ b/src/osd/libretro/window.cpp
@@ -401,6 +401,9 @@ int retro_window_info::window_init()
 	// reset sound timer (set in `sound_manager::update` to `retro_fps`)
 	sound_timer = 0;
 
+	// reset machine aspect (set in `retro_window_info::update()`)
+	view_aspect = 1;
+
 	// handle error conditions
 	if (result == 1)
 		goto error;


### PR DESCRIPTION
- Bring back reasonable default maximum, and grow only when needed
- Reset view aspect on `window_init()`, fixes aspect when using internal reset