### PR TITLE
Experimental fix for crashing on uwp/xbox

### DIFF
--- a/src/osd/osdsync.cpp
+++ b/src/osd/osdsync.cpp
@@ -88,14 +88,14 @@ static void spin_while_not(const volatile _AtomType * volatile atom, const _Main
 
 int osd_get_num_processors(bool heavy_mt)
 {
-#if defined(SDLMAME_EMSCRIPTEN)
-	// multithreading is not supported at this time
+	// test for xbox
 	return 1;
-#else
+
+
 	unsigned int threads = std::thread::hardware_concurrency();
 	// max out at 4 for now since scaling above that seems to do poorly
 	return heavy_mt ? threads : std::min(std::thread::hardware_concurrency(), 4U);
-#endif
+
 }
 
 //============================================================
@@ -274,11 +274,9 @@ osd_work_queue *osd_work_queue_alloc(int flags)
 
 	if (osdworkqueuemaxthreads != nullptr && sscanf(osdworkqueuemaxthreads, "%d", &osdthreadnum) == 1 && threadnum > osdthreadnum)
 		threadnum = osdthreadnum;
-
-#if defined(SDLMAME_EMSCRIPTEN)
-	// threads are not supported at all
+	
+	// threads are not supported at all test for xbox
 	threadnum = 0;
-#endif
 
 	// clamp to the maximum
 	queue->threads = std::min(threadnum, WORK_MAX_THREADS);


### PR DESCRIPTION
Games that use any type of threading on mame crashes retroarch back to dash on Xbox consoles. 

This fix should allow for all mame games to now work correctly with no crashing. 