### PR TITLE
fix compile

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -119,23 +119,23 @@ endif
 
 ifeq ($(platform),android-arm)
 #buildbot fix
-	ifneq ($(ANDROID_NDK_ROOT),) 
+	ifneq ($(ANDROID_NDK_ROOT),)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += android-arm 
+	PLATFLAGS += android-arm
 	LIBRETRO_CPU :=
 	ARCH :=
 	LIBRETRO_OS :=
-	PTR64 := 
+	PTR64 :=
 endif
 ifeq ($(platform),android-arm64)
 #buildbot fix
-	ifneq ($(ANDROID_NDK_ROOT),) 
+	ifneq ($(ANDROID_NDK_ROOT),)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += android-arm64 
+	PLATFLAGS += android-arm64
 	LIBRETRO_CPU :=
 	ARCH :=
 	LIBRETRO_OS :=
@@ -143,7 +143,7 @@ ifeq ($(platform),android-arm64)
 endif
 ifeq ($(platform),android-x86)
 #buildbot fix
-	ifneq ($(ANDROID_NDK_ROOT),) 
+	ifneq ($(ANDROID_NDK_ROOT),)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
@@ -155,11 +155,11 @@ ifeq ($(platform),android-x86)
 endif
 ifeq ($(platform),android-x86_64)
 #buildbot fix
-	ifneq ($(ANDROID_NDK_ROOT),) 
+	ifneq ($(ANDROID_NDK_ROOT),)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += android-x64 
+	PLATFLAGS += android-x64
 	LIBRETRO_CPU :=
 	ARCH :=
 	LIBRETRO_OS :=
@@ -170,7 +170,7 @@ ifneq ($(ANDROID_NDK_HOME),)
 OK := $(shell if [ -d $(ANDROID_NDK_HOME) ]; then echo "ok"; fi)
 ifeq ($(OK),)
 $(error  path $(ANDROID_NDK_HOME) does not exist! please set ANDROID_NDK_HOME!)
-else 
+else
 $(info  ANDROID_NDK_HOME path is a valid directory $(ANDROID_NDK_HOME))
 endif
 endif
@@ -192,8 +192,8 @@ ifeq ($(platform),osx)
 		CPPFLAGS += $(TARGET_RULE)
 		CXXFLAGS += $(TARGET_RULE)
 		LDFLAGS  += $(TARGET_RULE)
-		PLATFLAGS += TARGETOS="macosx" 
-		PTR64 :=
+		PLATFLAGS += TARGETOS="macosx"
+		PTR64 = 1
    endif
 
 endif
@@ -207,14 +207,14 @@ ifeq ($(platform),ios-arm64)
 	PLATFLAGS += USE_QTDEBUG=0
 	PLATFLAGS += LIBRETRO_IOS=1
 	LIBRETRO_CPU = arm64
-	PLATFLAGS += TARGETOS="macosx" 
+	PLATFLAGS += TARGETOS="macosx"
 	LIBRETRO_OS = ios-arm64
 	IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
 	CC = cc -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
 	CXX = c++ -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
 	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
 	BUILDFLAGS += OPTIMIZE=z
-	PTR64 :=
+	PTR64 =1
 endif
 
 ifeq ($(platform),tvos-arm64)
@@ -225,14 +225,14 @@ ifeq ($(platform),tvos-arm64)
 	PLATFLAGS += USE_QTDEBUG=0
 	PLATFLAGS += LIBRETRO_TVOS=1
 	LIBRETRO_CPU = arm64
-	PLATFLAGS += TARGETOS="macosx" 
+	PLATFLAGS += TARGETOS="macosx"
 	LIBRETRO_OS = tvos-arm64
 	IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
 	CC = cc -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK)
 	CXX = c++ -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK)
 	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
 	BUILDFLAGS += OPTIMIZE=z
-	PTR64 :=
+	PTR64 =1
 endif
 
 ifneq ($(LIBRETRO_CPU),)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -210,8 +210,8 @@ ifeq ($(platform),ios-arm64)
 	PLATFLAGS += TARGETOS="macosx"
 	LIBRETRO_OS = ios-arm64
 	IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
-	CC = cc -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
-	CXX = c++ -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
+	CC = clang -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
+	CXX = clang++ -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
 	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
 	BUILDFLAGS += OPTIMIZE=z
 	PTR64 =1
@@ -228,8 +228,8 @@ ifeq ($(platform),tvos-arm64)
 	PLATFLAGS += TARGETOS="macosx"
 	LIBRETRO_OS = tvos-arm64
 	IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
-	CC = cc -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK)
-	CXX = c++ -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK)
+	CC = clang -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK)
+	CXX = clang++ -arch $(LIBRETRO_CPU) -isysroot $(IOSSDK)
 	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
 	BUILDFLAGS += OPTIMIZE=z
 	PTR64 =1

--- a/makefile
+++ b/makefile
@@ -1211,7 +1211,7 @@ android-ndk:
 ifndef ANDROID_NDK_HOME
 	$(error ANDROID_NDK_HOME is not set)
 endif
-ifneq ($(OSD), retro) 
+ifneq ($(OSD), retro)
 ifndef SDL_INSTALL_ROOT
 	$(error SDL_INSTALL_ROOT is not set)
 endif
@@ -1230,7 +1230,7 @@ endif
 # android-arm
 #-------------------------------------------------
 
-ifeq ($(OSD), retro) 
+ifeq ($(OSD), retro)
 #RETRO HACK no sdl for libretro android
 $(PROJECTDIR)/$(MAKETYPE)-android-arm/Makefile: makefile $(SCRIPTS) $(GENIE)
 	$(SILENT) $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=android-arm --gcc_version=$(CLANG_VERSION) --osd=retro --targetos=android --PLATFORM=arm --NO_USE_MIDI=1 --NO_OPENGL=1 --USE_QTDEBUG=0 --DONT_USE_NETWORK=1 --NOASM=1 $(MAKETYPE)
@@ -1253,7 +1253,7 @@ endif # ifdef RETRO
 # android-arm64
 #-------------------------------------------------
 
-ifeq ($(OSD), retro) 
+ifeq ($(OSD), retro)
 #RETRO HACK no sdl for libretro android
 $(PROJECTDIR)/$(MAKETYPE)-android-arm64/Makefile: makefile $(SCRIPTS) $(GENIE)
 	$(SILENT) $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=android-arm64 --gcc_version=$(CLANG_VERSION) --osd=retro --targetos=android --PLATFORM=arm64 --NO_USE_MIDI=1 --NO_OPENGL=1 --USE_QTDEBUG=0 --DONT_USE_NETWORK=1 --NOASM=1 $(MAKETYPE)
@@ -1275,7 +1275,7 @@ endif # ifdef RETRO
 #-------------------------------------------------
 # android-x86
 #-------------------------------------------------
-ifeq ($(OSD), retro) 
+ifeq ($(OSD), retro)
 #RETRO HACK no sdl for libretro android
 $(PROJECTDIR)/$(MAKETYPE)-android-x86/Makefile: makefile $(SCRIPTS) $(GENIE)
 	$(SILENT)  $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=android-x86 --gcc_version=$(CLANG_VERSION) --osd=retro --targetos=android --PLATFORM=x86 --NO_USE_MIDI=1 --NO_OPENGL=1 --USE_QTDEBUG=0 --DONT_USE_NETWORK=1 --NOASM=1 $(MAKETYPE)
@@ -1298,7 +1298,7 @@ endif
 # android-x64
 #-------------------------------------------------
 
-ifeq ($(OSD), retro) 
+ifeq ($(OSD), retro)
 $(PROJECTDIR)/$(MAKETYPE)-android-x64/Makefile: makefile $(SCRIPTS) $(GENIE)
 	$(SILENT) $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=android-x64 --gcc_version=$(CLANG_VERSION) --osd=retro --targetos=android --PLATFORM=x64 --NO_USE_MIDI=1 --NO_OPENGL=1 --USE_QTDEBUG=0 --DONT_USE_NETWORK=1 --NOASM=1 $(MAKETYPE)
 
@@ -1585,12 +1585,14 @@ openbsd_x86_clang: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd-clang/Makefile
 #-------------------------------------------------
 
 GENIE_SRC=$(wildcard 3rdparty/genie/src/host/*.c)
+#no idea why the old patch skipped since its for the host this we will need to make sure PTR64 is set
+#since this is only for the host genie compile the right flag should be there anyway.
 ifneq ($(MPARAM),)
 	ifneq ($(LIBRETRO_OS),$(filter $(LIBRETRO_OS),tvos-arm64 ios-arm64, osx ))
 		$(info Please make fix the makefile.libretro to not not include -m32 and -m64 on $(LIBRETRO_OS) build. Its has been unset for now )
 		MPARAM :=
 	endif
-endif 
+endif
 
 $(GENIE): $(GENIE_SRC)
 	$(SILENT) $(MAKE) $(MAKEPARAMS) -C 3rdparty/genie/build/gmake.$(GENIEOS) -f genie.make MPARAM=$(MPARAM)


### PR DESCRIPTION
We need to recompile genie and this isint happening with the cache enabled.  This will fix the 64bit pointer and  still keep the patch someone put in for it (looking at the commit seems like the  the makefile didnt have MPARA )  when it compiles genie.  The old code missed one or two MAKE_CC in the genie.makefile. 