### PR TITLE
two more tests

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -207,6 +207,7 @@ ifeq ($(platform),ios-arm64)
 	PLATFLAGS += NO_OPENGL=1
 	PLATFLAGS += USE_QTDEBUG=0
 	PLATFLAGS += LIBRETRO_IOS=1
+	PLATFLAGS += LDOPTS="-arch $(LIBRETRO_CPU)"
 	LIBRETRO_CPU = arm64
 	PLATFLAGS += TARGETOS="macosx"
 	LIBRETRO_OS = ios-arm64
@@ -215,6 +216,7 @@ ifeq ($(platform),ios-arm64)
 	CXX = clang++ -arch $(LIBRETRO_CPU) -target $(LIBRETRO_APPLE_PLATFORM) -isysroot $(IOSSDK) -miphoneos-version-min=12.0
 	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
 	BUILDFLAGS += OPTIMIZE=z
+
 	PTR64 =1
 endif
 
@@ -227,6 +229,7 @@ ifeq ($(platform),tvos-arm64)
 	PLATFLAGS += NO_OPENGL=1
 	PLATFLAGS += USE_QTDEBUG=0
 	PLATFLAGS += LIBRETRO_TVOS=1
+	PLATFLAGS += LDOPTS="-arch $(LIBRETRO_CPU)"
 	LIBRETRO_CPU = arm64
 	PLATFLAGS += TARGETOS="macosx"
 	LIBRETRO_OS = tvos-arm64
@@ -234,7 +237,7 @@ ifeq ($(platform),tvos-arm64)
 	CC = clang -arch $(LIBRETRO_CPU) -target $(LIBRETRO_APPLE_PLATFORM) -isysroot $(IOSSDK)
 	CXX = clang++ -arch $(LIBRETRO_CPU) -target $(LIBRETRO_APPLE_PLATFORM)  -isysroot $(IOSSDK)
 	PLATFLAGS += OVERRIDE_CC="$(CC)" OVERRIDE_CXX="$(CXX)"
-	BUILDFLAGS += OPTIMIZE=z
+	#BUILDFLAGS += OPTIMIZE=z
 	PTR64 =1
 endif
 

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -705,7 +705,14 @@ else
 		"LSB_FIRST",
 	}
 	-- For iOS in libretro, don't specify the arch since it's already specified in $(CC) and $(CXX)
-	if _OPTIONS["targetos"]=="macosx"  and _OPTIONS["LIBRETRO_IOS"] ~= "1" and _OPTIONS["LIBRETRO_TVOS"] ~= "1" and _OPTIONS["LIBRETRO_OSX_ARM64"] then
+	if _OPTIONS["targetos"]=="macosx"  and _OPTIONS["LIBRETRO_IOS"] ~= "1" and _OPTIONS["LIBRETRO_TVOS"] ~= "1" and _OPTIONS["LIBRETRO_OSX_ARM64"]~= "1" then
+		configuration { "arm64" }
+			buildoptions {
+				"-arch arm64",
+			}
+			linkoptions {
+				"-arch arm64",
+			}
 		configuration { "x64", "not arm64" }
 			buildoptions {
 				"-arch x86_64",


### PR DESCRIPTION
The optimation=z has been removed in one and ive added -arch arm64 to the ld flags like upstream does to both.  If none of these work out need we to change the code.


https://github.com/libretro/mame/blob/47d05fe9401add01c366fb5ff8aee5606d3ca7de/scripts/genie.lua#L708-L725

The code needs fixed it never evaluates to true but is a non issue for libretro so thats for another day. Ok fixed it upstream compiles will work

```
make  platform=tvos-arm64 TARGETOS=macosx VERBOSE=1 PLATFORM=x86 -j6 CC=clang REGENIE=1 PTR64=1
gets ( -arch x86_64)

make  platform=tvos-arm64 TARGETOS=macosx VERBOSE=1 PLATFORM=x86 -j6 CC=clang REGENIE=1 
( gets -arch i386)

make  platform=tvos-arm64 TARGETOS=macosx VERBOSE=1 PLATFORM=arm64 -j6 CC=clang REGENIE=1 PTR64=1
( gets -arch arm64)

```
This hack can be removed in the future but its a none issue here anyway as we setting it at cc and things are working as they should be for our makefile. Im not sure why we even have optimization=z set.