### PR TITLE
try static link libs for android

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -540,10 +540,16 @@ if string.sub(_ACTION,1,4) == "vs20" and _OPTIONS["osd"]=="sdl" then
 end
 -- Build SDL2 for Android
 if _OPTIONS["osd"] == "retro" then
+	if _OPTIONS["targetos"]=="android" then
+		linkoptions {
+			"-static-libgcc -static-libstdc++"
+		}
+	end
 -- RETRO HACK no sdl for libretro android
 else
 if _OPTIONS["targetos"] == "android" then
 	_OPTIONS["with-bundled-sdl2"] = "1"
+
 end
 end
 -- RETRO HACK END no sdl for libretro android


### PR DESCRIPTION
untested should fix the issue. Done a tiny build for amr64

[android.zip](https://github.com/libretro/mame/files/12166001/android.zip)

looks like you need to either include the dll or statically link it.
https://developer.android.com/ndk/guides/cpp-support
 

game supported are if this doesnt work ill dig in more at the weekend
```
game_driver const *const driver_list::s_drivers_sorted[60] =
{
	&GAME_NAME(___empty),
	&GAME_NAME(alienar),
	&GAME_NAME(carpolo),
	&GAME_NAME(circus),
	&GAME_NAME(circuso),
	&GAME_NAME(crash),
	&GAME_NAME(fax),
	&GAME_NAME(fax2),
	&GAME_NAME(fireone),
	&GAME_NAME(gridlee),
	&GAME_NAME(hardhat),
	&GAME_NAME(looping),
	&GAME_NAME(ripcord),
	&GAME_NAME(robby),
	&GAME_NAME(robotbwl),
	&GAME_NAME(sidetrac),
	&GAME_NAME(spectar),
	&GAME_NAME(starfir2),
	&GAME_NAME(starfire),
	&GAME_NAME(starfirea),
	&GAME_NAME(supertnk),
	&GAME_NAME(targ),
	&GAME_NAME(teetert),
	&GAME_NAME(topgunnr),
	&GAME_NAME(victorba),
	&GAME_NAME(victory),
	&GAME_NAME(witchgme),
	&GAME_NAME(witchjol),
	&GAME_NAME(wldwitch),
	&GAME_NAME(wldwitcha),
	&GAME_NAME(wldwitchc),
	&GAME_NAME(wldwitchd),
	&GAME_NAME(wldwitchf),
	&GAME_NAME(wldwitchg),
	&GAME_NAME(wldwitchh),
	&GAME_NAME(wldwitchi),
	&GAME_NAME(wldwitchj),
	&GAME_NAME(wldwitchk),
	&GAME_NAME(wldwitchl),
	&GAME_NAME(wldwitchm),
	&GAME_NAME(wldwitchn),
	&GAME_NAME(wldwitcho),
	&GAME_NAME(wldwitchp),
	&GAME_NAME(wldwitchq),
	&GAME_NAME(wldwitchr),
	&GAME_NAME(wldwitchs),
	&GAME_NAME(wldwitcht),
	&GAME_NAME(wldwitchu),
	&GAME_NAME(wldwitchv),
	&GAME_NAME(wrally),
	&GAME_NAME(wstrike),
	&GAME_NAME(wstrikea),
	&GAME_NAME(wtchjack),
	&GAME_NAME(wtchjacka),
	&GAME_NAME(wtchjackb),
	&GAME_NAME(wupndown),
	&GAME_NAME(wupndowna),
	&GAME_NAME(wupndownb),
	&GAME_NAME(wupndownc),
	&GAME_NAME(wupndownd),

```
