### PR TITLE
Use keyboard events instead of states

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -739,12 +739,14 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;
 
+   static struct retro_keyboard_callback keyboard_callback = {retro_keyboard_event};
+   environ_cb(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &keyboard_callback);
+
    memset(videoBuffer, 0, sizeof(videoBuffer));
    init_output_audio_buffer(2048);
 
    retro_pause = 0;
 }
-
 
 void retro_deinit(void)
 {

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -98,8 +98,6 @@ extern int lightgunX[8];
 extern int lightgunY[8];
 extern int lightgunBUT[4];
 
-extern unsigned short retrokbd_state[RETROK_LAST];
-
 extern int fb_width;
 extern int fb_height;
 extern float retro_aspect;
@@ -115,6 +113,8 @@ extern retro_environment_t environ_cb;
 extern retro_input_state_t input_state_cb;
 extern retro_input_poll_t input_poll_cb;
 
+extern void retro_keyboard_event(bool, unsigned, uint32_t, uint16_t);
+
 void retro_frame_draw_enable(bool enable);
 
 void *retro_get_fb_ptr(void);
@@ -129,6 +129,5 @@ int mmain(int argc, char *argv[]);
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif

--- a/src/osd/modules/input/input_retro.h
+++ b/src/osd/modules/input/input_retro.h
@@ -47,8 +47,7 @@ struct kt_table
    input_item_id mame_key;
 };
 
-extern unsigned short retrokbd_state[RETROK_LAST];
-extern unsigned short retrokbd_state2[RETROK_LAST];
+extern void retro_keyboard_event(bool, unsigned, uint32_t, uint16_t);
 extern kt_table const ktable[];
 
 extern int mouseLX[8];
@@ -58,9 +57,6 @@ extern int lightgunX[8];
 extern int lightgunY[8];
 
 extern Joystate joystate[8];
-
-extern int fb_width;
-extern int fb_height;
 
 template <typename Info>
 class retro_input_module : public input_module_impl<Info, retro_osd_interface>


### PR DESCRIPTION
Gets rid of duplicate key presses to frontend and core when using keyboard.
