### PR TITLE
Startup fps fixes

### DIFF
--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -41,6 +41,7 @@ float view_aspect  = 1.0f;
 float retro_fps    = 60.0f;
 float sound_timer  = 50.0f; /* default STREAMS_UPDATE_ATTOTIME, changed later to `retro_fps` */
 int video_changed  = 0;
+int screen_configured = 0;
 
 static bool draw_this_frame;
 static int cpu_overclock = 100;

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -55,6 +55,7 @@ enum
    RETRO_SETTING_LIGHTGUN_MODE_LIGHTGUN
 };
 
+extern bool retro_load_ok;
 extern int video_changed;
 extern int retro_pause;
 extern int mame_reset;
@@ -105,6 +106,9 @@ extern float retro_fps;
 extern float view_aspect;
 extern int rotation_mode;
 extern int thread_mode;
+extern float sound_timer;
+extern int screen_configured;
+
 static const char core[] = "mame";
 
 /* libretro callbacks */

--- a/src/osd/libretro/osdretro.h
+++ b/src/osd/libretro/osdretro.h
@@ -7,10 +7,6 @@
 
 #include "libretro-internal/libretro_shared.h"
 
-extern float sound_timer;
-extern float retro_fps;
-extern int video_changed;
-
 //============================================================
 //  Defines
 //============================================================

--- a/src/osd/libretro/window.cpp
+++ b/src/osd/libretro/window.cpp
@@ -36,12 +36,13 @@
 #include "modules/render/drawretro.h"
 #include "modules/monitor/monitor_common.h"
 
+#include "libretro-internal/libretro_shared.h"
+
 extern int max_width;
 extern int max_height;
 extern int libretro_rotation_allow;
 extern int internal_rotation_allow;
 extern int norotate;
-extern bool retro_load_ok;
 
 //============================================================
 //  PARAMETERS
@@ -293,6 +294,9 @@ int retro_window_info::window_init()
 	// reset sound timer (set in `sound_manager::update` to `retro_fps`)
 	sound_timer = 0;
 
+	// reset screen configuration
+	screen_configured = 0;
+
 	// reset machine aspect (set in `retro_window_info::update()`)
 	view_aspect = 1;
 
@@ -481,11 +485,13 @@ void retro_window_info::update()
 			/* Update retro_fps */
 			if (screen)
 			{
-				float current_screen_refresh = screen->frame_period().as_hz();
+				float screen_refresh = screen->frame_period().as_hz();
 
-				if (current_screen_refresh != retro_fps)
+				if (screen_refresh != retro_fps
+						&& screen_refresh <= 120.0f
+						&& screen_refresh >= 30.0f)
 				{
-					retro_fps = current_screen_refresh;
+					retro_fps     = screen_refresh;
 					video_changed = 1;
 				}
 			}


### PR DESCRIPTION
For problem cases such as `pong` and `breakout`:
- Filter out absurd refresh rates that also disable frontend vsync
- Add a hack for stopping endless and useless screen configuration + slowdown

Might help out with #408

There still are a few extra `SET_SYSTEM_AV_INFO` calls that cause video reinits, but not much can be done about those. 