### PR TITLE
precompile for android on buildbot

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -137,10 +137,11 @@ ifeq ($(platform),android-arm)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += TARGETOS=android-arm gcc=android-arm PLATFORM=arm
+	PLATFLAGS += TARGETOS=android-arm gcc=android-arm PLATFORM=arm PRECOMPILE=1
 	LIBRETRO_CPU :=
 	LIBRETRO_OS :=
 	PTR64 :=
+
 endif
 ifeq ($(platform),android-arm64)
 #buildbot fix
@@ -148,7 +149,7 @@ ifeq ($(platform),android-arm64)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += TARGETOS=android-arm64 gcc=android-arm64 PLATFORM=arm64
+	PLATFLAGS += TARGETOS=android-arm64 gcc=android-arm64 PLATFORM=arm64 PRECOMPILE=1
 	LIBRETRO_CPU :=
 	LIBRETRO_OS :=
 	PTR64 :=
@@ -159,7 +160,7 @@ ifeq ($(platform),android-x86)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += TARGETOS=android-x86 gcc=android-x86 PLATFORM=x86
+	PLATFLAGS += TARGETOS=android-x86 gcc=android-x86 PLATFORM=x86 PRECOMPILE=1
 	LIBRETRO_CPU :=
 	LIBRETRO_OS :=
 	PTR64 :=
@@ -170,7 +171,7 @@ ifeq ($(platform),android-x86_64)
 	ANDROID_NDK_HOME=$(ANDROID_NDK_ROOT)
 	endif
 	export ANDROID_NDK_HOME ?= /opt/ndk
-	PLATFLAGS += TARGETOS=android-x64 gcc=android-x64 PLATFORM=x64
+	PLATFLAGS += TARGETOS=android-x64 gcc=android-x64 PLATFORM=x64 PRECOMPILE=1
 	LIBRETRO_CPU :=
 	LIBRETRO_OS :=
 	PTR64 :=


### PR DESCRIPTION
```
fatal error: file '/builds/libretro/mame/build/projects/retro/mamearcade/gmake-android-arm64/../../../../../src/emu/device.ipp' has been modified since the precompiled header '../../../../libretro/obj/libretro/emu.h.gch' was built: mtime changed
note: please rebuild precompiled header '../../../../libretro/obj/libretro/emu.h.gch'
1 error generated.
```

see if this fixes us up not sure if the mess and mame builds are causing this as i dont know how the cache works between the two builds