### PR TITLE
fix a problem which can't build a  Arcade MAME (arcade.flt) of the driver cv1k.cpp.

### DIFF
--- a/scripts/src/video.lua
+++ b/scripts/src/video.lua
@@ -260,6 +260,28 @@ if (VIDEOS["EF9365"]~=null) then
 end
 
 --------------------------------------------------
+--@src/devices/video/ep1c12.h,VIDEOS["EP1C12"] = true
+--------------------------------------------------
+
+--if (VIDEOS["EP1C12"]~=null) then
+	files {
+		MAME_DIR .. "src/mame/cave/ep1c12.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12.h",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit0.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit1.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit2.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit3.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit4.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit5.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit6.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit7.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12_blit8.cpp",
+		MAME_DIR .. "src/mame/cave/ep1c12in.hxx",
+		MAME_DIR .. "src/mame/cave/ep1c12pixel.hxx",
+	}
+--end
+
+--------------------------------------------------
 --
 --@src/devices/video/fixfreq.h,VIDEOS["FIXFREQ"] = true
 --------------------------------------------------

--- a/scripts/src/video.lua
+++ b/scripts/src/video.lua
@@ -276,8 +276,8 @@ end
 		MAME_DIR .. "src/mame/cave/ep1c12_blit6.cpp",
 		MAME_DIR .. "src/mame/cave/ep1c12_blit7.cpp",
 		MAME_DIR .. "src/mame/cave/ep1c12_blit8.cpp",
-		MAME_DIR .. "src/mame/cave/ep1c12in.hxx",
-		MAME_DIR .. "src/mame/cave/ep1c12pixel.hxx",
+		MAME_DIR .. "src/mame/cave/ep1c12in.ipp",
+		MAME_DIR .. "src/mame/cave/ep1c12pixel.ipp",
 	}
 --end
 


### PR DESCRIPTION
after rename epic12 to ep1c12, 
https://github.com/mamedev/mame/commit/11be240aaae7f919e280819f21efbf8e5326cab0
https://github.com/mamedev/mame/commit/af0706e4c7be0a4b7b42a673c1ad679f1e76b1e7

fix a problem which can't build a  Arcade MAME (arcade.flt) of the driver cv1k.cpp.