### PR TITLE
Libretro loop MACHINE_NOTIFY_FRAME hiscore plugin fix

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -1394,6 +1394,7 @@ void running_machine::emscripten_load(const char *name) {
 //**************************************************************************
 
 #if defined(__LIBRETRO__)
+extern int POSTNOTIFY;
 extern int RLOOP;
 extern int ENDEXEC;
 
@@ -1418,7 +1419,12 @@ void running_machine::retro_loop()
 	// get most recent input now 
 	m_manager.osd().input_update(true);
 	// perform tasks for this frame
-	call_notifiers(MACHINE_NOTIFY_FRAME);
+	// except start using this "next frame input response" pre-frame notify
+	// after allowing a few startup frames for hiscore plugin to init properly
+	if (POSTNOTIFY)
+		POSTNOTIFY--;
+	else
+		call_notifiers(MACHINE_NOTIFY_FRAME);
 
 	while (RLOOP == 1)
 	{

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -29,6 +29,9 @@
 
 #include "rendersw.hxx"
 
+#if defined(__LIBRETRO__)
+extern int POSTNOTIFY;
+#endif
 
 //**************************************************************************
 //  DEBUGGING
@@ -257,7 +260,10 @@ void video_manager::frame_update(bool from_debugger)
 
 	if (!from_debugger)
 	{
-#if !defined(__LIBRETRO__)
+#if defined(__LIBRETRO__)
+		if (POSTNOTIFY)
+			machine().call_notifiers(MACHINE_NOTIFY_FRAME);
+#else
 		// perform tasks for this frame
 		machine().call_notifiers(MACHINE_NOTIFY_FRAME);
 #endif

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -34,6 +34,7 @@
 #include <ctime>
 
 #if defined(__LIBRETRO__)
+int POSTNOTIFY = 2;
 int ENDEXEC = 0;
 extern int RLOOP;
 extern mame_machine_manager *retro_manager;


### PR DESCRIPTION
Doing `MACHINE_NOTIFY_FRAME` in the retro loop before frame update produces next frame input response, but causes issues at least with hiscore plugin by either not loading hiscores on startup (invaders) or completely failing to boot (strider2).

So instead of hassling with manual editing of `hiscore.dat` let's just circle around the problem by allowing `MACHINE_NOTIFY_FRAME` to fire up in the expected place for a few frames on startup, and then switch to the libretro loop.

Closes #452
