### PR TITLE
libretro: add android x86 for play store, fix compilation with updated NDK

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,11 +238,20 @@ android-x86_64:
     - master
     - /^libretro/mame.*$/
     
-# # Android 32-bit x86
-# android-x86:
-#   extends:
-#     - .libretro-android-jni-x86
-#     - .core-defs
+# Android x86
+android-x86:
+  extends:
+    - .libretro-android-make-x86
+    - .core-defs
+  variables:
+    TARGET:    mame
+    SUBTARGET: arcade
+    CORENAME:  mamearcade
+  cache:
+    <<: *global_cache
+  only:
+    - master
+    - /^libretro/mame.*$/
 
 # iOS
 libretro-build-ios-arm64:

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -475,18 +475,6 @@ function toolchain(_buildDir, _subDir)
 
 	configuration { "android-*" }
 		objdir (_buildDir .. "android/obj/" .. _OPTIONS["PLATFORM"])
-		includedirs {
-			MAME_DIR .. "3rdparty/bgfx/3rdparty/khronos",
-			--  LIBRETRO: don't mess with NDK includir order
-			-- "$(ANDROID_NDK_HOME)/sources/cxx-stl/llvm-libc++/libcxx/include",
-			-- "$(ANDROID_NDK_HOME)/sources/cxx-stl/llvm-libc++/include",
-			-- "$(ANDROID_NDK_HOME)/sysroot/usr/include",
-			-- "$(ANDROID_NDK_HOME)/sources/android/support/include",
-			-- "$(ANDROID_NDK_HOME)/sources/android/native_app_glue",
-		}
-		linkoptions {
-			"-nostdlib",
-		}
 		flags {
 			"NoImportLib",
 		}
@@ -496,29 +484,23 @@ function toolchain(_buildDir, _subDir)
 			"m",
 			"android",
 			"log",
-			"c++_static",
-			"c++abi",
-			"stdc++",
 		}
 		buildoptions_c {
-			"-Wno-strict-prototypes",
+			"--gcc-toolchain=" .. androidToolchainRoot(),
+			"--sysroot=" .. androidToolchainRoot() .. "/sysroot",
 		}
 		buildoptions {
+			"--gcc-toolchain=" .. androidToolchainRoot(),
+			"--sysroot=" .. androidToolchainRoot() .. "/sysroot",
 			"-fpic",
 			"-ffunction-sections",
 			"-funwind-tables",
 			"-fstack-protector-strong",
 			"-no-canonical-prefixes",
-			"-Wunused-value",
-			"-Wundef",
-			"-Wno-cast-align",
-			"-Wno-unknown-attributes",
-			"-Wno-macro-redefined",
-			"-DASIO_HAS_STD_STRING_VIEW",
-			"-Wno-unused-function",
 		}
 		linkoptions {
-			"-no-canonical-prefixes",
+			"--gcc-toolchain=" .. androidToolchainRoot(),
+			"--sysroot=" .. androidToolchainRoot() .. "/sysroot",
 			"-Wl,--no-undefined",
 			"-Wl,-z,noexecstack",
 			"-Wl,-z,relro",
@@ -526,104 +508,44 @@ function toolchain(_buildDir, _subDir)
 		}
 
 	configuration { "android-arm" }
-			libdirs {
-				"$(ANDROID_NDK_HOME)/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a",
-				androidToolchainRoot() .. "/sysroot/usr/lib/arm-linux-androideabi/" .. androidApiLevel,
-			}
-			includedirs {
-			}
 			buildoptions {
-				"--gcc-toolchain=" .. androidToolchainRoot(),
-				"-target armv7-linux-androideabi" .. androidApiLevel,
+				"--target=armv7-none-linux-android" .. androidApiLevel,
 				"-march=armv7-a",
 				"-mfloat-abi=softfp",
-				"-mfpu=vfpv3-d16",
+				"-mfpu=neon",
 				"-mthumb",
 			}
-			links {
-				"android_support",
-				"unwind",
-				"gcc",
-			}
 			linkoptions {
-				"--gcc-toolchain=" .. androidToolchainRoot(),
-				"--sysroot=" .. androidToolchainRoot() .. "/sysroot/usr/lib/arm-linux-androideabi/" .. androidApiLevel,
-
-				androidToolchainRoot()  .. "/sysroot/usr/lib/arm-linux-androideabi/" .. androidApiLevel .. "/crtbegin_so.o",
-				androidToolchainRoot()  .. "/sysroot/usr/lib/arm-linux-androideabi/" .. androidApiLevel .. "/crtend_so.o",
-				"-target armv7-linux-androideabi" .. androidApiLevel,
+				"--target=armv7-none-linux-android" .. androidApiLevel,
+				"-march=armv7-a",
 			}
 
 	configuration { "android-arm64" }
-			libdirs {
-				"$(ANDROID_NDK_HOME)/sources/cxx-stl/llvm-libc++/libs/arm64-v8a",
-				androidToolchainRoot() .. "/sysroot/usr/lib/aarch64-linux-android/" .. androidApiLevel,
-			}
-			includedirs {
-			}
 			buildoptions {
-				"--gcc-toolchain=" .. androidToolchainRoot(),
-				"-target aarch64-linux-android" .. androidApiLevel,
-				"-march=armv8-a",
-			}
-			links {
-				"gcc",
+				"--target=aarch64-none-linux-android" .. androidApiLevel,
 			}
 			linkoptions {
-				"--gcc-toolchain=" .. androidToolchainRoot(),
-				"--sysroot=" .. androidToolchainRoot() .. "/sysroot/usr/lib/aarch64-linux-android/" .. androidApiLevel,
-				androidToolchainRoot() .. "/sysroot/usr/lib/aarch64-linux-android/" .. androidApiLevel .. "/crtbegin_so.o",
-				androidToolchainRoot() .. "/sysroot/usr/lib/aarch64-linux-android/" .. androidApiLevel .. "/crtend_so.o",
-				"-target aarch64-linux-android" .. androidApiLevel,
+				"--target=aarch64-none-linux-android" .. androidApiLevel,
 			}
 
 	configuration { "android-x86" }
-			libdirs {
-				"$(ANDROID_NDK_HOME)/sources/cxx-stl/llvm-libc++/libs/x86",
-				androidToolchainRoot() .. "/sysroot/usr/lib/i686-linux-android/" .. androidApiLevel,
-			}
-			includedirs {
-			}
-			buildoptions {
-				"--gcc-toolchain=" .. androidToolchainRoot(),
-				"-target i686-linux-android" .. androidApiLevel,
-				"-mtune=atom",
-				"-mstackrealign",
-				"-msse3",
-				"-mfpmath=sse",
-			}
-			links {
-				"gcc",
-			}
-			linkoptions {
-				"--gcc-toolchain=" .. androidToolchainRoot(),
-				"--sysroot=" .. androidToolchainRoot() .. "/sysroot/usr/lib/i686-linux-android/" .. androidApiLevel,
-				androidToolchainRoot() .. "/sysroot/usr/lib/i686-linux-android/" .. androidApiLevel .. "/crtbegin_so.o",
-				androidToolchainRoot() .. "/sysroot/usr/lib/i686-linux-android/" .. androidApiLevel .. "/crtend_so.o",
-				"-target i686-linux-android" .. androidApiLevel,
-			}
-
-
-	configuration { "android-x64" }
-		libdirs {
-			"$(ANDROID_NDK_HOME)/sources/cxx-stl/llvm-libc++/libs/x86_64",
-			androidToolchainRoot() .. "/sysroot/usr/lib/x86_64-linux-android/" .. androidApiLevel,
-		}
-		includedirs {
-		}
 		buildoptions {
-			"--gcc-toolchain=" .. androidToolchainRoot(),
-			"-target x86_64-linux-android" .. androidApiLevel,
-		}
-		links {
-			"gcc",
+			"--target=i686-none-linux-android" .. androidApiLevel,
+			"-mtune=atom",
+			"-mstackrealign",
+			"-msse3",
+			"-mfpmath=sse",
 		}
 		linkoptions {
-			"--gcc-toolchain=" .. androidToolchainRoot(),
-			"--sysroot=" .. androidToolchainRoot() .. "/sysroot/usr/lib/x86_64-linux-android/" .. androidApiLevel,
-			androidToolchainRoot() .. "/sysroot/usr/lib/x86_64-linux-android/" .. androidApiLevel .. "/crtbegin_so.o",
-			androidToolchainRoot() .. "/sysroot/usr/lib/x86_64-linux-android/" .. androidApiLevel .. "/crtend_so.o",
-			"-target x86_64-linux-android" .. androidApiLevel,
+			"--target=i686-none-linux-android" .. androidApiLevel,
+		}
+
+	configuration { "android-x64" }
+		buildoptions {
+			"--target=x86_64-none-linux-android" .. androidApiLevel,
+		}
+		linkoptions {
+			"--target=x86_64-none-linux-android" .. androidApiLevel,
 		}
 
 	configuration { "asmjs" }

--- a/src/mame/sgi/pm2_mmu.cpp
+++ b/src/mame/sgi/pm2_mmu.cpp
@@ -57,7 +57,7 @@ static constexpr u8 R = 1U << device_memory_interface::TR_READ;
 static constexpr u8 W = 1U << device_memory_interface::TR_WRITE;
 static constexpr u8 X = 1U << device_memory_interface::TR_FETCH;
 
-static u8 constexpr access[2][8] =
+static constexpr u8 ACCESS[2][8] =
 {
 	{      0,     0,     0,     X, R  |X, R|W|X,     0,     0 }, // user
 	{      0, R  |X, R|W|X, R|W|X, R|W|X, R|W|X,     0,     0 }, // supervisor
@@ -158,7 +158,7 @@ std::optional<std::pair<unsigned, offs_t>> pm2_mmu_device::translate(offs_t cons
 				return std::nullopt;
 
 			// check protection
-			if (!BIT(access[m_super][BIT(prot, 8, 3)], intention))
+			if (!BIT(ACCESS[m_super][BIT(prot, 8, 3)], intention))
 				return std::nullopt;
 
 			// update reference and modify bits


### PR DESCRIPTION
Let's go!

Also fixes this compiler failure:
```
/usr/lib/android-sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++    -MMD -MP -MP -D__LIBRETRO__ -DNDEBUG -DCRLF=2 -DLSB_FIRST -DFLAC__NO_DLL -DPUGIXML_HEADER_ONLY -DMAME_NOASM -DNATIVE_DRC=drcbe_c -DLUA_COMPAT_ALL -DLUA_COMPAT_5_1 -DLUA_COMPAT_5_2 -I"../../../../../3rdparty/bgfx/3rdparty/khronos" -I"../../../../../src/osd" -I"../../../../../src/emu" -I"../../../../../src/devices" -I"../../../../../src/mame/shared" -I"../../../../../src/lib" -I"../../../../../src/lib/util" -I"../../../../../3rdparty" -I"../../../../generated/mame/layout" -I"../../../../../3rdparty/asio/include" -I"../../../../../3rdparty/flac/include" -I"../../../../../3rdparty/glm" -I"../../../../../3rdparty/libjpeg" -I"../../../../../3rdparty/rapidjson/include" -I"../../../../../3rdparty/zlib"  -std=c++17 -fPIC -pipe -O3 -fno-strict-aliasing -Wno-unknown-pragmas -Wall -Wcast-align -Wformat-security -Wundef -Wwrite-strings -Wno-conversion -Wno-sign-compare -Wno-error=deprecated-declarations -fdiagnostics-show-note-include-stack -Wno-cast-align -Wno-constant-logical-operand -Wno-extern-c-compat -Wno-ignored-qualifiers -Wno-pragma-pack -Wno-unknown-attributes -Wno-unknown-warning-option -Wno-unused-value -Wno-unused-const-variable -Wno-xor-used-as-pow -Wno-bitwise-instead-of-logical -fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -Wunused-value -Wno-macro-redefined -DASIO_HAS_STD_STRING_VIEW -Wno-unused-function --gcc-toolchain=/usr/lib/android-sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64 -target i686-linux-android24 -mtune=atom -mstackrealign -msse3 -mfpmath=sse -fsigned-char -Wno-error=undef -Wno-error=macro-redefined -std=c++17 -Woverloaded-virtual -Wvla -include /home/cscd98/Developer/mame/src/osd/libretro/retroprefix.h -o "../../../../libretro/obj/libretro/src/mame/sgi/vc1.o" -c "../../../../../src/mame/sgi/vc1.cpp"
../../../../../src/mame/sgi/pm2_mmu.cpp:60:21: error: redefinition of 'access' as different kind of symbol
   60 | static u8 constexpr access[2][8] =
      |                     ^
In file included from ../../../../../src/mame/sgi/pm2_mmu.cpp:14:
In file included from ../../../../../src/emu/emu.h:33:
In file included from ../../../../../src/emu/emucore.h:27:
In file included from ../../../../../src/lib/util/coretmpl.h:16:
In file included from ../../../../../src/lib/util/vecstream.h:25:
In file included from /usr/lib/android-sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/istream:170:
In file included from /usr/lib/android-sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/ostream:194:
In file included from /usr/lib/android-sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/print:53:
/usr/lib/android-sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/unistd.h:266:5: note: previous definition is here
  266 | int access(const char* _Nonnull __path, int __mode);
      |     ^
../../../../../src/mame/sgi/pm2_mmu.cpp:161:13: error: subscript of pointer to function type 'int (const char * _Nonnull, int)'
  161 |                         if (!BIT(access[m_super][BIT(prot, 8, 3)], intention))
      |                                  ^~~~~~
2 errors generated.
make[3]: *** [sgi.make:1067: ../../../../libretro/obj/libretro/src/mame/sgi/pm2_mmu.o] Error 1
make[3]: *** Waiting for unfinished jobs....
Compiling src/mame/suna/goindol.cpp...
```

This was also fixed upstream: https://github.com/mamedev/mame/commit/b55ba81d2a417df3e0ee9260be06425550f13541