### PR TITLE
libretro: still need to static link c++ with new NDK

### DIFF
--- a/3rdparty/bx/scripts/toolchain.lua
+++ b/3rdparty/bx/scripts/toolchain.lua
@@ -753,7 +753,9 @@ function toolchain(_buildDir, _libDir)
 			"m",
 			"android",
 			"log",
-			"c++_shared",
+-- RETRO HACK for libretro android
+			-- "c++_shared",
+-- RETRO HACK END for libretro android
 		}
 		buildoptions {
 			"--gcc-toolchain=" .. androidToolchainRoot(),

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -501,6 +501,9 @@ function toolchain(_buildDir, _subDir)
 		linkoptions {
 			"--gcc-toolchain=" .. androidToolchainRoot(),
 			"--sysroot=" .. androidToolchainRoot() .. "/sysroot",
+-- RETRO HACK for libretro android
+			"-static-libstdc++",
+-- RETRO HACK END for libretro android
 			"-Wl,--no-undefined",
 			"-Wl,-z,noexecstack",
 			"-Wl,-z,relro",


### PR DESCRIPTION
We still need -static-libstdc++, otherwise on Android it will fail trying to load c++_shared with the newest r27d NDK