### PR TITLE
libretro: disable REGENIE by default, remove x86 android

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,19 +239,19 @@ android-x86_64:
     - /^libretro/mame.*$/
     
 # Android x86
-android-x86:
-  extends:
-    - .libretro-android-make-x86
-    - .core-defs
-  variables:
-    TARGET:    mame
-    SUBTARGET: arcade
-    CORENAME:  mamearcade
-  cache:
-    <<: *global_cache
-  only:
-    - master
-    - /^libretro/mame.*$/
+#android-x86:
+#  extends:
+#    - .libretro-android-make-x86
+#    - .core-defs
+#  variables:
+#    TARGET:    mame
+#    SUBTARGET: arcade
+#    CORENAME:  mamearcade
+#  cache:
+#    <<: *global_cache
+#  only:
+#    - master
+#    - /^libretro/mame.*$/
 
 # iOS
 libretro-build-ios-arm64:

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -9,7 +9,7 @@ TARGET ?= mame
 # OS ?= linux
 # TARGETOS ?= linux
 PYTHON_EXECUTABLE ?= python3
-REGENIE ?= 1
+REGENIE ?= 0
 GITHUB_REPO ?= https://github.com/libretro/mame/
 DEBUG ?= 0
 


### PR DESCRIPTION
android-x86 was added as a requirement for the play store, this is no longer required.

Setting REGENIE to 0 by default *might* improve cached build times.