### PR TITLE
libretro: change windows (mingw) to use GCC 14

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,7 @@ libretro-build-windows-x64:
   extends:
     - .libretro-windows-x64-mingw-make-default
     - .core-defs
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-mxe-win-cross-cores:gcc14
   cache:
     <<: *global_cache
   only:
@@ -107,6 +108,7 @@ libretro-build-windows-i686:
   extends:
     - .libretro-windows-i686-mingw-make-default
     - .core-defs
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-mxe-win-cross-cores:gcc14
   cache:
     <<: *global_cache
   only:


### PR DESCRIPTION
Don't merge this yet as mame cache needs to be cleared first