### PR TITLE
ci: turn the Android x86 job back on

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,19 +244,19 @@ android-x86_64:
     - /^libretro/mame.*$/
     
 # Android x86
-#android-x86:
-#  extends:
-#    - .libretro-android-make-x86
-#    - .core-defs
-#  variables:
-#    TARGET:    mame
-#    SUBTARGET: arcade
-#    CORENAME:  mamearcade
-#  cache:
-#    <<: *global_cache
-#  only:
-#    - master
-#    - /^libretro/mame.*$/
+android-x86:
+  extends:
+    - .libretro-android-make-x86
+    - .core-defs
+  variables:
+    TARGET:    mame
+    SUBTARGET: arcade
+    CORENAME:  mamearcade
+  cache:
+    <<: *global_cache
+  only:
+    - master
+    - /^libretro/mame.*$/
 
 # iOS
 libretro-build-ios-arm64:


### PR DESCRIPTION
`android-x86` is the one ABI commented out in `.gitlab-ci.yml`, and it builds today. Uncommenting it is the whole change.

I ran it on a GitHub runner with the same `platform=android-x86` line the other three ABIs use, NDK 29.0.14206865, `TARGET=mame SUBTARGET=arcade`:

```
clang++ -o ../../../../../mamearcade_libretro_android.so ... --target=i686-none-linux-android24 ...
-rwxr-xr-x 1 runner runner 249255316 mamearcade_libretro_android.so
mamearcade_libretro_android.so: ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, stripped
```

Nothing else needed touching — no source changes, no flags beyond what the `android-make` template already passes. 32-bit is not a problem for this tree in general either: `linux-i686`, `windows-i686` and `android-armeabi-v7a` are all active and green.

I have not run it on the buildbot's own image, so if there is a reason this was switched off that is not "it did not build", I have not seen it — the commit that commented it out would know better than I do.
